### PR TITLE
Add initial support for command completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
     "highlight.js": "11.0.1",
-    "ink": "^5.0.1",
+    "ink": "^5.1.0",
     "ink-spinner": "^5.0.0",
     "ink-use-stdout-dimensions": "^1.0.5",
     "react": "^18.3.1",
@@ -46,5 +46,10 @@
     "split2": "^4.2.0",
     "string-width": "^7.2.0",
     "strip-ansi": "^7.1.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "ink": "patches/ink.patch"
+    }
   }
 }

--- a/patches/ink.patch
+++ b/patches/ink.patch
@@ -1,0 +1,23 @@
+diff --git a/build/styles.js b/build/styles.js
+index 91c54445639cdf31dbb75c5ecdc2042991c837eb..ec2e4214156810f48297ea461f2949d321777ff7 100644
+--- a/build/styles.js
++++ b/build/styles.js
+@@ -5,6 +5,18 @@ const applyPositionStyles = (node, style) => {
+             ? Yoga.POSITION_TYPE_ABSOLUTE
+             : Yoga.POSITION_TYPE_RELATIVE);
+     }
++    if ('top' in style) {
++        node.setPosition(Yoga.EDGE_TOP, style.top || 0);
++    }
++    if ('bottom' in style) {
++        node.setPosition(Yoga.EDGE_BOTTOM, style.bottom || 0);
++    }
++    if ('left' in style) {
++        node.setPosition(Yoga.EDGE_LEFT, style.left || 0);
++    }
++    if ('right' in style) {
++        node.setPosition(Yoga.EDGE_RIGHT, style.right || 0);
++    }
+ };
+ const applyMarginStyles = (node, style) => {
+     if ('margin' in style) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  ink:
+    hash: 4zs6u7zfx2hrh3klcma7bkxgsq
+    path: patches/ink.patch
+
 importers:
 
   .:
@@ -27,14 +32,14 @@ importers:
         specifier: 11.0.1
         version: 11.0.1
       ink:
-        specifier: ^5.0.1
-        version: 5.0.1(react@18.3.1)
+        specifier: ^5.1.0
+        version: 5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1)
       ink-spinner:
         specifier: ^5.0.0
-        version: 5.0.0(ink@5.0.1(react@18.3.1))(react@18.3.1)
+        version: 5.0.0(ink@5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1))(react@18.3.1)
       ink-use-stdout-dimensions:
         specifier: ^1.0.5
-        version: 1.0.5(ink@5.0.1(react@18.3.1))(react@18.3.1)
+        version: 1.0.5(ink@5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -225,6 +230,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.32.0:
+    resolution: {integrity: sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -320,8 +328,8 @@ packages:
       ink: '>=2.0.0'
       react: '>=16.0.0'
 
-  ink@5.0.1:
-    resolution: {integrity: sha512-ae4AW/t8jlkj/6Ou21H2av0wxTk8vrGzXv+v2v7j4in+bl1M5XRMVbfNghzhBokV++FjF8RBDJvYo+ttR9YVRg==}
+  ink@5.1.0:
+    resolution: {integrity: sha512-3vIO+CU4uSg167/dZrg4wHy75llUINYXxN4OsdaCkE40q4zyOTPwNc2VEpLnnWsIvIQeo6x6lilAhuaSt+rIsA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -341,8 +349,8 @@ packages:
     resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
     engines: {node: '>=18'}
 
-  is-in-ci@0.1.0:
-    resolution: {integrity: sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==}
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -354,9 +362,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -567,8 +572,8 @@ packages:
   tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
 
-  type-fest@4.26.1:
-    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
+  type-fest@4.33.0:
+    resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
     engines: {node: '>=16'}
 
   url@0.11.4:
@@ -845,6 +850,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-toolkit@1.32.0: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
@@ -922,18 +929,18 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink-spinner@5.0.0(ink@5.0.1(react@18.3.1))(react@18.3.1):
+  ink-spinner@5.0.0(ink@5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1))(react@18.3.1):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 5.0.1(react@18.3.1)
+      ink: 5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1)
       react: 18.3.1
 
-  ink-use-stdout-dimensions@1.0.5(ink@5.0.1(react@18.3.1))(react@18.3.1):
+  ink-use-stdout-dimensions@1.0.5(ink@5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1))(react@18.3.1):
     dependencies:
-      ink: 5.0.1(react@18.3.1)
+      ink: 5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1)
       react: 18.3.1
 
-  ink@5.0.1(react@18.3.1):
+  ink@5.1.0(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@18.3.1):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.1.3
       ansi-escapes: 7.0.0
@@ -944,9 +951,9 @@ snapshots:
       cli-cursor: 4.0.0
       cli-truncate: 4.0.0
       code-excerpt: 4.0.0
+      es-toolkit: 1.32.0
       indent-string: 5.0.0
-      is-in-ci: 0.1.0
-      lodash: 4.17.21
+      is-in-ci: 1.0.0
       patch-console: 2.0.0
       react: 18.3.1
       react-reconciler: 0.29.2(react@18.3.1)
@@ -955,7 +962,7 @@ snapshots:
       slice-ansi: 7.1.0
       stack-utils: 2.0.6
       string-width: 7.2.0
-      type-fest: 4.26.1
+      type-fest: 4.33.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
       ws: 8.18.0
@@ -970,15 +977,13 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.2.0
 
-  is-in-ci@0.1.0: {}
+  is-in-ci@1.0.0: {}
 
   isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  lodash@4.17.21: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -1249,7 +1254,7 @@ snapshots:
 
   tty-browserify@0.0.0: {}
 
-  type-fest@4.26.1: {}
+  type-fest@4.33.0: {}
 
   url@0.11.4:
     dependencies:

--- a/src/cli/saya/cli/text_input.cljs
+++ b/src/cli/saya/cli/text_input.cljs
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [reagent.core :as r]
    [saya.cli.input :refer [use-keys]]
+   [saya.modules.completion.helpers :refer [word-to-complete]]
    [saya.modules.ui.cursor :refer [cursor]]))
 
 (defn- split-text-by-state [{:keys [cursor]} value]
@@ -18,7 +19,47 @@
 (defn- inc-to-max [v max-value]
   (min (inc v) max-value))
 
-(defn- on-key [{:keys [on-change on-key on-submit]} state-ref value key]
+(defn- try-update-completion [state {:keys [word] :as new-state}]
+  (when word
+    (if (str/starts-with? word (:word state))
+      ; Further typing; don't change
+      state
+      new-state)))
+
+(defn- clamp-to-candidates [candidates idx]
+  (when-not (>= idx (count candidates))
+    idx))
+
+(defn next-candidate [state index-pred value completion]
+  (let [state' (-> state
+                   (update :completion try-update-completion completion))
+        candidates (get-in state' [:completion :candidates])]
+    (if (seq candidates)
+      (let [state' (update-in state' [:completion :index]
+                              (comp
+                               (partial clamp-to-candidates candidates)
+                               index-pred))
+            new-candidate (if-some [n (:index (:completion state'))]
+                            (nth candidates n)
+                            ; Replace with the original input
+                            (:word (:completion state')))
+
+            [before after] (split-text-by-state state' value)
+            completed-before (word-to-complete {:line-before-cursor before})
+            before' (subs before 0 (- (count before)
+                                      (count completed-before)))
+            result (str before'
+                        new-candidate
+                        after)]
+        (-> state'
+            (assoc :cursor (+ (count before') (count new-candidate)))
+            (assoc-in [:completion :result] result)))
+
+      state')))
+
+(defn- on-key [{:keys [completion-candidates completion-word
+                       on-change on-key on-submit]}
+               state-ref value key]
   (match [key]
     [:return] (on-submit value)
     [:delete] (let [[_ new-state] (swap-vals! state-ref update :cursor dec-to-zero)
@@ -40,6 +81,12 @@
                                      (subs value cursor))
                                 last-word-start))
 
+    [:tab] (let [new-completion {:word completion-word :candidates completion-candidates}
+                 [_ new-state] (swap-vals! state-ref next-candidate (fnil inc -1) value new-completion)]
+             ; This is pretty gross:
+             (when-let [value' (:result (:completion new-state))]
+               (on-change value')))
+
     [(key :guard string?)] (let [[old-state {:keys [cursor]}] (swap-vals! state-ref
                                                                           update
                                                                           :cursor + (count key))
@@ -49,7 +96,8 @@
 
     :else (on-key key)))
 
-(defn text-input [{:keys [value _on-change _on-key _on-submit] :as params
+(defn text-input [{:keys [value _ghost _completion-candidates _completion-word
+                          _on-change _on-key _on-submit] :as params
                    cursor-shape :cursor}]
   (r/with-let [state-ref (r/atom {:cursor 0})]
     (use-keys :text-input (partial on-key params state-ref value))
@@ -58,4 +106,10 @@
       [:> k/Text
        [:> k/Text before]
        [cursor (or cursor-shape :block)]
+       ; NOTE: ghost is *cool* but the delay between re-frame updating
+       ; the ghost and react updating the text is awful. Perhaps if we
+       ; moved to storing state in the DB and using `dispatch-sync` we
+       ; could do this...
+       ; (when (seq ghost)
+       ;   [:> k/Text {:dim-color true} ghost])
        [:> k/Text after]])))

--- a/src/cli/saya/cli/text_input.cljs
+++ b/src/cli/saya/cli/text_input.cljs
@@ -24,7 +24,7 @@
     [:delete] (let [[_ new-state] (swap-vals! state-ref update :cursor dec-to-zero)
                     [before after] (split-text-by-state new-state value)
                     new-value (str before (subs after 1))]
-                (on-change new-value))
+                (on-change new-value (:cursor new-state)))
 
     [:ctrl/a] (swap! state-ref assoc :cursor 0)
     [:ctrl/e] (swap! state-ref assoc :cursor (count value))
@@ -37,14 +37,15 @@
                          last-word-start (or (str/last-index-of value " " cursor) 0)]
                      (swap! state-ref assoc :cursor last-word-start)
                      (on-change (str (subs value 0 last-word-start)
-                                     (subs value cursor))))
+                                     (subs value cursor))
+                                last-word-start))
 
-    [(key :guard string?)] (let [[old-state _] (swap-vals! state-ref
-                                                           update
-                                                           :cursor + (count key))
+    [(key :guard string?)] (let [[old-state {:keys [cursor]}] (swap-vals! state-ref
+                                                                          update
+                                                                          :cursor + (count key))
                                  [before after] (split-text-by-state old-state value)
                                  new-value (str before key after)]
-                             (on-change new-value))
+                             (on-change new-value cursor))
 
     :else (on-key key)))
 

--- a/src/cli/saya/cli/text_input.cljs
+++ b/src/cli/saya/cli/text_input.cljs
@@ -21,8 +21,8 @@
 
 (defn- try-update-completion [state {:keys [word] :as new-state}]
   (when word
-    (if (str/starts-with? word (:word state))
-      ; Further typing; don't change
+    (if (some? (:index state))
+      ; If there's a non-nil index, we're cycling through candidates
       state
       new-state)))
 

--- a/src/cli/saya/cli/text_input.cljs
+++ b/src/cli/saya/cli/text_input.cljs
@@ -85,7 +85,10 @@
                  [_ new-state] (swap-vals! state-ref next-candidate (fnil inc -1) value new-completion)]
              ; This is pretty gross:
              (when-let [value' (:result (:completion new-state))]
-               (on-change value')))
+               (on-change value' (:cursor new-state)
+                          {:applied-candidate (when-some [idx (:index (:completion new-state))]
+                                                (nth (:candidates (:completion new-state))
+                                                     idx))})))
 
     [(key :guard string?)] (let [[old-state {:keys [cursor]}] (swap-vals! state-ref
                                                                           update

--- a/src/cli/saya/events.cljs
+++ b/src/cli/saya/events.cljs
@@ -31,6 +31,12 @@
  (fn [_ [width height]]
    {:width width :height height}))
 
+(reg-event-db
+ ::set-global-cursor
+ [trim-v (path :cursor)]
+ (fn [_ [position]]
+   position))
+
 (reg-event-fx
  :submit-raw-command
  [trim-v]

--- a/src/cli/saya/modules/command/completion.cljs
+++ b/src/cli/saya/modules/command/completion.cljs
@@ -1,0 +1,18 @@
+(ns saya.modules.command.completion
+  (:require
+   [clojure.string :as str]
+   [promesa.core :as p]
+   [saya.modules.command.registry :refer [registered-commands]]
+   [saya.modules.completion.helpers :as helpers]
+   [saya.modules.completion.proto :refer [ICompletionSource]]))
+
+(defrecord CommandCompletionSource []
+  ICompletionSource
+  (gather-candidates [_this context]
+    (let [word (helpers/word-to-complete context)]
+      (p/do
+        (->> @registered-commands
+             keys
+             (map name)
+             ; TODO: Possibly, fuzzy:
+             (filter #(str/starts-with? % word)))))))

--- a/src/cli/saya/modules/command/view.cljs
+++ b/src/cli/saya/modules/command/view.cljs
@@ -2,6 +2,7 @@
   (:require
    ["ink" :as k]
    [archetype.util :refer [<sub >evt]]
+   [saya.modules.command.completion :refer [->CommandCompletionSource]]
    [saya.modules.command.events :as events]
    [saya.modules.command.subs :as subs]
    [saya.modules.input.window :refer [input-window]]))
@@ -14,6 +15,7 @@
    [input-window {:initial-value (when-not (= :cmd (<sub [:current-bufnr]))
                                    (<sub [::subs/input-text]))
                   :bufnr :cmd
+                  :completion (->CommandCompletionSource)
                   :on-prepare-buffer #(>evt [::events/prepare-buffer %])
                   :on-submit #(>evt [:submit-raw-command %])
                   :before ":"}]])

--- a/src/cli/saya/modules/completion/events.cljs
+++ b/src/cli/saya/modules/completion/events.cljs
@@ -1,0 +1,36 @@
+(ns saya.modules.completion.events
+  (:require
+   [re-frame.core :refer [reg-event-db trim-v unwrap]]))
+
+(reg-event-db
+ ::start
+ [unwrap]
+ (fn [db {:keys [bufnr word-to-complete]}]
+   (assoc-in db [:buffers bufnr :completion :word-to-complete] word-to-complete)))
+
+(reg-event-db
+ ::on-candidates
+ [unwrap]
+ (fn [db {:keys [bufnr candidates]}]
+   (assoc-in db [:buffers bufnr :completion :candidates] candidates)))
+
+(reg-event-db
+ ::on-error
+ [unwrap]
+ (fn [db {:keys [bufnr _error]}]
+   (update-in db [:buffers bufnr :completion] dissoc :candidates)))
+
+(reg-event-db
+ ::set-bufnr
+ [trim-v]
+ (fn [db [bufnr]]
+   (assoc-in db [:completion :current-bufnr] bufnr)))
+
+(reg-event-db
+ ::unset-bufnr
+ [trim-v]
+ (fn [db [bufnr]]
+   (update-in db [:completion :current-bufnr] (fn [v]
+                                                (if (= v bufnr)
+                                                  nil
+                                                  v)))))

--- a/src/cli/saya/modules/completion/events.cljs
+++ b/src/cli/saya/modules/completion/events.cljs
@@ -9,6 +9,12 @@
    (assoc-in db [:buffers bufnr :completion :word-to-complete] word-to-complete)))
 
 (reg-event-db
+ ::on-applied-candidate
+ [unwrap]
+ (fn [db {:keys [bufnr candidate]}]
+   (assoc-in db [:buffers bufnr :completion :applied-candidate] candidate)))
+
+(reg-event-db
  ::on-candidates
  [unwrap]
  (fn [db {:keys [bufnr candidates]}]

--- a/src/cli/saya/modules/completion/helpers.cljs
+++ b/src/cli/saya/modules/completion/helpers.cljs
@@ -1,0 +1,32 @@
+(ns saya.modules.completion.helpers
+  (:require
+   [archetype.util :refer [>evt]]
+   [clojure.string :as str]
+   [promesa.core :as p]
+   [saya.modules.completion.events :as events]
+   [saya.modules.completion.proto :as proto :refer [ICompletionSource]]
+   [saya.modules.logging.core :refer [log]]))
+
+(defn word-to-complete [{:keys [line-before-cursor]}]
+  (if line-before-cursor
+    (if-some [last-whitespace-idx (str/last-index-of line-before-cursor " ")]
+      (subs line-before-cursor (inc last-whitespace-idx))
+      line-before-cursor)
+    ""))
+
+(defn refresh-completion [^ICompletionSource source, bufnr line cursor]
+  (let [line-before-cursor (subs line 0 cursor)
+        context {:line-before-cursor line-before-cursor}
+        word-to-complete (word-to-complete context)]
+    (>evt [::events/start {:bufnr bufnr
+                           :word-to-complete word-to-complete
+                           :line-before-cursor line-before-cursor}])
+
+    (when (seq word-to-complete)
+      (-> (p/let [candidates (proto/gather-candidates source context)]
+            (>evt [::events/on-candidates {:bufnr bufnr
+                                           :candidates (seq candidates)}]))
+          (p/catch (fn [e]
+                     (log "ERROR in completion: " e)
+                     (>evt [::events/on-error {:bufnr bufnr
+                                               :error e}])))))))

--- a/src/cli/saya/modules/completion/proto.cljs
+++ b/src/cli/saya/modules/completion/proto.cljs
@@ -1,0 +1,4 @@
+(ns saya.modules.completion.proto)
+
+(defprotocol ICompletionSource
+  (gather-candidates [this {:keys [line-before-cursor]}]))

--- a/src/cli/saya/modules/completion/subs.cljs
+++ b/src/cli/saya/modules/completion/subs.cljs
@@ -24,11 +24,20 @@
  :-> :word-to-complete)
 
 (reg-sub
+ ::applied-candidate
+ :<- [::state]
+ :-> :applied-candidate)
+
+(reg-sub
  ::left-offset
+ :<- [::applied-candidate]
  :<- [::word-to-complete]
- :-> (fn [word-to-complete]
-       (when (seq word-to-complete)
-         (- (count word-to-complete)))))
+ :-> (fn [[applied-candidate word-to-complete]]
+       (or (when (seq applied-candidate)
+             (- (count applied-candidate)))
+
+           (when (seq word-to-complete)
+             (- (count word-to-complete))))))
 
 (reg-sub
  ::candidates

--- a/src/cli/saya/modules/completion/subs.cljs
+++ b/src/cli/saya/modules/completion/subs.cljs
@@ -19,9 +19,14 @@
  :-> :completion)
 
 (reg-sub
- ::left-offset
+ ::word-to-complete
  :<- [::state]
- :-> (fn [{:keys [word-to-complete]}]
+ :-> :word-to-complete)
+
+(reg-sub
+ ::left-offset
+ :<- [::word-to-complete]
+ :-> (fn [word-to-complete]
        (when (seq word-to-complete)
          (- (count word-to-complete)))))
 
@@ -29,3 +34,13 @@
  ::candidates
  :<- [::state]
  :-> :candidates)
+
+(reg-sub
+ ::ghost
+ :<- [::left-offset]
+ :<- [::candidates]
+ :-> (fn [[left-offset candidates]]
+       (let [ghost-offset (- left-offset)
+             candidate (first candidates)]
+         (when (> (count candidate) ghost-offset)
+           (subs candidate ghost-offset)))))

--- a/src/cli/saya/modules/completion/subs.cljs
+++ b/src/cli/saya/modules/completion/subs.cljs
@@ -1,0 +1,31 @@
+(ns saya.modules.completion.subs
+  (:require
+   [re-frame.core :refer [reg-sub]]))
+
+(reg-sub
+ ::current-bufnr
+ :-> #(get-in % [:completion :current-bufnr]))
+
+(reg-sub
+ ::current-buffer
+ :<- [:buffers]
+ :<- [::current-bufnr]
+ (fn [[buffers bufnr]]
+   (get buffers bufnr)))
+
+(reg-sub
+ ::state
+ :<- [::current-buffer]
+ :-> :completion)
+
+(reg-sub
+ ::left-offset
+ :<- [::state]
+ :-> (fn [{:keys [word-to-complete]}]
+       (when (seq word-to-complete)
+         (- (count word-to-complete)))))
+
+(reg-sub
+ ::candidates
+ :<- [::state]
+ :-> :candidates)

--- a/src/cli/saya/modules/completion/view.cljs
+++ b/src/cli/saya/modules/completion/view.cljs
@@ -4,17 +4,19 @@
    [saya.modules.completion.subs :as subs]
    [saya.modules.popup.view :refer [popup-menu pum-line]]))
 
-(defn completion-line [& text]
+(defn completion-line [{:keys [selected?]} & text]
   ; TODO: Theming, I suppose?
-  (into [pum-line {:background-color :gray}]
+  (into [pum-line {:background-color :gray
+                   :inverse selected?}]
         text))
 
 (defn completion-menu []
   (let [left-offset (<sub [::subs/left-offset])
+        applied-candidate (<sub [::subs/applied-candidate])
         candidates (<sub [::subs/candidates])]
     (when left-offset
       [popup-menu {:flex-direction :column
                    :left left-offset}
        (for [c candidates]
          ^{:key c}
-         [completion-line c])])))
+         [completion-line {:selected? (= c applied-candidate)} c])])))

--- a/src/cli/saya/modules/completion/view.cljs
+++ b/src/cli/saya/modules/completion/view.cljs
@@ -1,12 +1,20 @@
 (ns saya.modules.completion.view
   (:require
+   [archetype.util :refer [<sub]]
+   [saya.modules.completion.subs :as subs]
    [saya.modules.popup.view :refer [popup-menu pum-line]]))
 
 (defn completion-line [& text]
-  (into [pum-line {:background-color :red}]
+  ; TODO: Theming, I suppose?
+  (into [pum-line {:background-color :gray}]
         text))
 
 (defn completion-menu []
-  [popup-menu {:flex-direction :column}
-   [completion-line "Hi!"]
-   [completion-line "There"]])
+  (let [left-offset (<sub [::subs/left-offset])
+        candidates (<sub [::subs/candidates])]
+    (when left-offset
+      [popup-menu {:flex-direction :column
+                   :left left-offset}
+       (for [c candidates]
+         ^{:key c}
+         [completion-line c])])))

--- a/src/cli/saya/modules/completion/view.cljs
+++ b/src/cli/saya/modules/completion/view.cljs
@@ -1,0 +1,12 @@
+(ns saya.modules.completion.view
+  (:require
+   [saya.modules.popup.view :refer [popup-menu pum-line]]))
+
+(defn completion-line [& text]
+  (into [pum-line {:background-color :red}]
+        text))
+
+(defn completion-menu []
+  [popup-menu {:flex-direction :column}
+   [completion-line "Hi!"]
+   [completion-line "There"]])

--- a/src/cli/saya/modules/completion/view.cljs
+++ b/src/cli/saya/modules/completion/view.cljs
@@ -16,7 +16,9 @@
         candidates (<sub [::subs/candidates])]
     (when left-offset
       [popup-menu {:flex-direction :column
-                   :left left-offset}
+                   :left (dec left-offset)} ; the dec accounts for the padding
        (for [c candidates]
          ^{:key c}
-         [completion-line {:selected? (= c applied-candidate)} c])])))
+         [completion-line {:selected? (= c applied-candidate)}
+          ; NOTE: "Fake" padding so we have a nice bg
+          " " c " "])])))

--- a/src/cli/saya/modules/input/window.cljs
+++ b/src/cli/saya/modules/input/window.cljs
@@ -8,6 +8,7 @@
    [saya.cli.text-input :refer [text-input]]
    [saya.modules.completion.events :as completion-events]
    [saya.modules.completion.helpers :refer [refresh-completion]]
+   [saya.modules.completion.subs :as completion-subs]
    [saya.modules.input.core :as input]
    [saya.modules.input.events :as events]
    [saya.modules.logging.core :refer [log]]))
@@ -30,6 +31,7 @@
                 (on-change "")
                 (when-not (seq input)
                   (>evt [::input/on-key key])))
+
     ; See input.core
     [:escape] (>evt [::input/on-key key])
     :else nil))
@@ -75,6 +77,9 @@
                      :on-change on-change
                      :on-key on-key
                      :cursor :pipe
+                     :completion-word (<sub [::completion-subs/word-to-complete])
+                     :completion-candidates (<sub [::completion-subs/candidates])
+                     :ghost (<sub [::completion-subs/ghost])
                      :on-submit (fn [v]
                                   (on-change v)
                                   (on-submit v))}]]])))

--- a/src/cli/saya/modules/input/window.cljs
+++ b/src/cli/saya/modules/input/window.cljs
@@ -43,9 +43,9 @@
   (r/with-let [input-ref (atom (or initial-value ""))]
     (let [[input set-input!] (React/useState @input-ref)
           on-change (React/useCallback
-                     (fn [v cursor]
+                     (fn [v cursor completion-opts]
                        (when completion
-                         (refresh-completion completion bufnr v cursor))
+                         (refresh-completion completion bufnr v cursor completion-opts))
                        (set-input! v)
                        (reset! input-ref v))
                      #js [])

--- a/src/cli/saya/modules/popup/view.cljs
+++ b/src/cli/saya/modules/popup/view.cljs
@@ -1,0 +1,64 @@
+(ns saya.modules.popup.view
+  (:require
+   ["ink" :as k]
+   ["react" :as React]
+   ["string-width" :default string-width]
+   [applied-science.js-interop :as j]
+   [archetype.util :refer [<sub]]
+   [clojure.string :as str]))
+
+(defonce ^:private popup-menu-context (React/createContext nil))
+
+(def ^:private clear-style "\u001b[49m")
+
+(defn pum-line
+  "Almost-drop-in replacement for k/Text that ensures the line fills the full
+   width of the popup. This is almost certainly a terrible idea and you should
+   probably just fill in space yourself"
+  [options & children]
+  (let [{:keys [width]} (React/useContext popup-menu-context)]
+    [:> k/Transform {:transform (fn [text]
+                                  (let [plain-length (string-width text)
+                                        text (cond-> text
+                                               (str/ends-with? text clear-style)
+                                               (subs 0 (- (count text)
+                                                          (count clear-style))))]
+                                    (apply str text (concat (repeat (- width plain-length) " ")
+                                                            [clear-style]))))}
+     (into [:> k/Text options] children)]))
+
+(defn popup-menu [options & children]
+  (let [box-ref (React/useRef)
+        [box-dimens set-box-dimens!] (React/useState)
+
+        {:keys [x y]} (<sub [:global-cursor])
+        {:keys [height]} (<sub [:dimens])
+        below? (<= y 5)
+        positioning (if below?
+                      {:top y}
+                      {:bottom (- height y)})]
+
+    (React/useLayoutEffect
+     (fn []
+       (when-some [el box-ref.current]
+         (j/let [^:js {:keys [width height]} (k/measureElement el)]
+           (set-box-dimens!
+            (fn [old-value]
+              (if (and (= (:width old-value) width)
+                       (= (:height old-value) height))
+                  ; Return exact same value to avoid re-render
+                old-value
+
+                {:width width :height height})))))
+
+       js/undefined))
+
+    (when x
+      [:r> popup-menu-context.Provider #js {:value box-dimens}
+       (into [:> k/Box (merge
+                        options
+                        positioning
+                        {:ref box-ref
+                         :position :absolute
+                         :left (+ x (:left options 0))})]
+             children)])))

--- a/src/cli/saya/modules/popup/view.cljs
+++ b/src/cli/saya/modules/popup/view.cljs
@@ -32,11 +32,12 @@
         [box-dimens set-box-dimens!] (React/useState)
 
         {:keys [x y]} (<sub [:global-cursor])
-        {:keys [height]} (<sub [:dimens])
+        {:keys [height width]} (<sub [:dimens])
         below? (<= y 5)
         positioning (if below?
                       {:top y}
-                      {:bottom (- height y)})]
+                      {:bottom (- height y)})
+        box-width (:width box-dimens)]
 
     (React/useLayoutEffect
      (fn []
@@ -60,5 +61,7 @@
                         positioning
                         {:ref box-ref
                          :position :absolute
-                         :left (+ x (:left options 0))})]
+                         :left (-> (+ x (:left options 0))
+                                   (max 0)
+                                   (min (- width box-width)))})]
              children)])))

--- a/src/cli/saya/subs.cljs
+++ b/src/cli/saya/subs.cljs
@@ -31,3 +31,6 @@
  (fn [[buffers bufnr]]
    (get buffers bufnr)))
 
+(reg-sub
+ :global-cursor
+ :-> :cursor)

--- a/src/cli/saya/views.cljs
+++ b/src/cli/saya/views.cljs
@@ -4,11 +4,16 @@
    [archetype.util :refer [<sub]]
    [saya.cli.fullscreen :refer [dimens-tracker fullscreen-box]]
    [saya.cli.input :as input]
+   [saya.modules.completion.view :refer [completion-menu]]
    [saya.modules.home.core :refer [home-view]]
    [saya.modules.ui.error-boundary :refer [error-boundary]]))
 
 (def ^:private pages
   {:home #'home-view})
+
+(defn- popup-menus []
+  [:<>
+   [completion-menu]])
 
 (defn main []
   (let [[page args] (<sub [:page])
@@ -29,4 +34,8 @@
            (str [page args])]]
 
          :else
-         page-form)]]]))
+         page-form)]]
+
+     ; Popup menus need to live here for absolute positioning to work correctly:
+     [error-boundary
+      [popup-menus]]]))

--- a/src/test/saya/cli/text_input_test.cljs
+++ b/src/test/saya/cli/text_input_test.cljs
@@ -1,0 +1,35 @@
+(ns saya.cli.text-input-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [saya.cli.text-input :refer [next-candidate]]))
+
+(deftest completion-test
+  (testing "Complete single candidate with no state"
+    (is (=
+         {:cursor 7
+          :completion {:word "c"
+                       :candidates ["connect"]
+                       :result "connect"
+                       :index 0}}
+         (next-candidate {:cursor 1}
+                         (fnil inc -1)
+                         "c"
+                         {:word "c"
+                          :candidates ["connect"]}))))
+
+  (testing "Reset to original after single candidate"
+    (is (=
+         {:cursor 1
+          :completion {:word "c"
+                       :candidates ["connect"]
+                       :result "c"
+                       :index nil}}
+         (next-candidate {:cursor 7
+                          :completion {:word "c"
+                                       :candidates ["connect"]
+                                       :result "connect"
+                                       :index 0}}
+                         (fnil inc -1)
+                         "connect"
+                         {:word "connect"
+                          :candidates ["connect"]})))))

--- a/src/test/saya/cli/text_input_test.cljs
+++ b/src/test/saya/cli/text_input_test.cljs
@@ -32,4 +32,22 @@
                          (fnil inc -1)
                          "connect"
                          {:word "connect"
+                          :candidates ["connect"]}))))
+
+  (testing "Ensure cycling works when restarting a continued completion"
+    ; EG: co<tab><s-tab>n<tab><s-tab> -> `con`
+    (is (=
+         {:cursor 7
+          :completion {:word "con"
+                       :candidates ["connect"]
+                       :result "connect"
+                       :index 0}}
+         (next-candidate {:cursor 7
+                          :completion {:word "co"
+                                       :candidates ["connect"]
+                                       :result "connect"
+                                       :index nil}}
+                         (fnil inc -1)
+                         "con"
+                         {:word "con"
                           :candidates ["connect"]})))))


### PR DESCRIPTION
This works like `{ preselect = false, auto_insert = true }` in blink.cmp. Future work *could* support other modes, but until someone requests it, this is my preferred UX so 🤷 

Basically, as you type we check for completion candidates; if any are found, we show them in a popup menu:

![Screenshot 2025-02-05 at 8 49 32 PM](https://github.com/user-attachments/assets/6065960e-9a49-4eb1-a200-9d47cd92c56b)

If you hit tab or shift tab, you can cycle through the candidates, and they will get inserted: 

![Screenshot 2025-02-05 at 8 49 22 PM](https://github.com/user-attachments/assets/16bb8a0c-37e8-4234-af8d-54273cf22537)

That way, when you've selected the one you want, you just keep typing.

Future work will integrate with Kodachi's completion RPC to support completion for connections.