### PR TITLE
Prepare support for basic insert-mode editing in "regular" buffers

### DIFF
--- a/src/cli/saya/cli/text_input.cljs
+++ b/src/cli/saya/cli/text_input.cljs
@@ -6,15 +6,9 @@
    [reagent.core :as r]
    [saya.cli.input :refer [use-keys]]
    [saya.cli.text-input.completion :refer [cycle-completion-candidates]]
-   [saya.cli.text-input.helpers :refer [split-text-by-state]]
+   [saya.cli.text-input.helpers :refer [dec-to-zero inc-to-max
+                                        split-text-by-state]]
    [saya.modules.ui.cursor :refer [cursor]]))
-
-(defn- dec-to-zero [v]
-  (cond-> v
-    (> v 0) (dec)))
-
-(defn- inc-to-max [v max-value]
-  (min (inc v) max-value))
 
 (defn- on-key [{:keys [completion-candidates _completion-word
                        on-change on-key on-submit]

--- a/src/cli/saya/cli/text_input/helpers.cljs
+++ b/src/cli/saya/cli/text_input/helpers.cljs
@@ -1,6 +1,16 @@
 (ns saya.cli.text-input.helpers)
 
+(defn dec-to-zero [v]
+  (cond-> v
+    (> v 0) (dec)))
+
+(defn inc-to-max [v max-value]
+  (min (inc v) max-value))
+
 (defn split-text-by-state [{:keys [cursor]} value]
-  [(subs value 0 cursor)
-   (subs value cursor)])
+  (let [idx (if (number? cursor)
+              cursor
+              (:col cursor))]
+    [(subs value 0 idx)
+     (subs value idx)]))
 

--- a/src/cli/saya/modules/command/registry.cljs
+++ b/src/cli/saya/modules/command/registry.cljs
@@ -1,6 +1,7 @@
 (ns saya.modules.command.registry
   (:require
    [re-frame.registrar :refer [get-handler]]
+   [saya.modules.command.registry.buffer]
    [saya.modules.command.registry.connection]
    [saya.modules.command.registry.core]))
 

--- a/src/cli/saya/modules/command/registry/buffer.cljs
+++ b/src/cli/saya/modules/command/registry/buffer.cljs
@@ -1,0 +1,19 @@
+(ns saya.modules.command.registry.buffer
+  (:require
+   [day8.re-frame-10x.inlined-deps.re-frame.v1v3v0.re-frame.core :refer [unwrap]]
+   [re-frame.core :refer [reg-event-fx]]
+   [saya.modules.buffers.events :as buffer-events]
+   [saya.modules.command.interceptors :refer [aliases]]
+   [saya.modules.logging.core :refer [log-fx]]))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(reg-event-fx
+ :command/enew
+ [(aliases :ene) unwrap]
+ (fn [{:keys [db]} _]
+   (if (some? (:current-winnr db))
+     ; TODO: echo errors + actually we *should* do this if unsaved
+     {:fx [(log-fx "Unable to :enew with an active buffer")]}
+
+     {:db (let [[db _] (buffer-events/create-blank db)]
+            db)})))

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -47,9 +47,9 @@
       [key]]
    (match [mode key {:bufnr? (some? bufnr)
                      :readonly? (or (some? connr)
-                                    (some? (some #{:readonly}
-                                                 (get-in db [:buffers bufnr :flags])))
-                                    false)
+                                    (some? (some
+                                            #{:readonly}
+                                            (get-in db [:buffers bufnr :flags]))))
                      :submit? (some? (get-in db [:windows winnr :on-submit]))}]
      [:normal ":" _] {:db (assoc db :mode :command)}
 

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -4,7 +4,6 @@
    [re-frame.core :refer [reg-event-fx trim-v]]
    [saya.modules.command.interceptors :refer [with-buffer-context]]
    [saya.modules.input.fx :as fx]
-   [saya.modules.input.helpers :refer [clamp-cursor]]
    [saya.modules.input.insert :as insert]
    [saya.modules.input.keymaps :as keymaps]
    [saya.modules.input.normal :as normal :refer [update-cursor]]))

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -86,7 +86,9 @@
       :with-unhandled (fn [cofx]
                         (if (string? key)
                           (try
-                            (insert/insert-at-buffer cofx key)
+                            (keymaps/perform
+                             cofx
+                             #(insert/insert-at-cursor % key))
                             (catch :default e
                               (assoc cofx :fx [[:log ["error: " e]]])))
 

--- a/src/cli/saya/modules/input/helpers.cljs
+++ b/src/cli/saya/modules/input/helpers.cljs
@@ -2,6 +2,8 @@
   (:require
    [saya.modules.ansi.split :as split]))
 
+(def ^:dynamic *mode* :normal)
+
 (defn current-buffer-line [{:keys [lines cursor]}]
   ; TODO: We should probably just store the :plain line...
   (->> (nth lines (:row cursor))
@@ -13,12 +15,14 @@
   (max 0
        (dec (count (:lines buffer)))))
 
-(defn current-buffer-eol-col [buffer]
-  (count (current-buffer-line buffer)))
-
 (defn current-buffer-line-last-col [buffer]
-  (max 0
-       (dec (current-buffer-eol-col buffer))))
+  (let [after-last-col (count (current-buffer-line buffer))]
+    (max 0
+         (case *mode*
+           :insert after-last-col
+
+           ; Usually, we don't want to be *after* the last col, we want to be *on* it
+           (dec after-last-col)))))
 
 (defn clamp-scroll [{:keys [window buffer] :as ctx}]
   (let [{:keys [height anchor-row]} window]

--- a/src/cli/saya/modules/input/helpers.cljs
+++ b/src/cli/saya/modules/input/helpers.cljs
@@ -13,9 +13,12 @@
   (max 0
        (dec (count (:lines buffer)))))
 
+(defn current-buffer-eol-col [buffer]
+  (count (current-buffer-line buffer)))
+
 (defn current-buffer-line-last-col [buffer]
   (max 0
-       (dec (count (current-buffer-line buffer)))))
+       (dec (current-buffer-eol-col buffer))))
 
 (defn clamp-scroll [{:keys [window buffer] :as ctx}]
   (let [{:keys [height anchor-row]} window]

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -1,0 +1,31 @@
+(ns saya.modules.input.insert
+  (:require
+   [clojure.string :as str]
+   [saya.modules.ansi.split :as split]
+   [saya.modules.input.normal :refer [to-end-of-line to-start-of-line]]))
+
+(def movement-keymaps
+  {[:ctrl/a] to-start-of-line
+   ; FIXME: actually go *after* eol
+   [:ctrl/e] to-end-of-line})
+
+; TODO: basic delete keymaps like :delete
+
+(def keymaps
+  (merge
+   movement-keymaps))
+
+(defn- insert-at-cursor [{:keys [lines cursor] :as buffer} key]
+  (let [linenr (:row cursor)
+        text (mapcat (comp split/chars-with-ansi :ansi)
+                     (nth lines linenr []))
+        line' (-> (take (:col cursor) text)
+                  (concat [key])
+                  (concat (drop (:col cursor) text))
+                  (str/join))]
+    (-> buffer
+        (assoc-in [:lines linenr] [{:ansi line' :plain line'}])
+        (update-in [:cursor :col] + (count key)))))
+
+(defn insert-at-buffer [{:keys [bufnr] :as cofx} key]
+  (update-in cofx [:db :buffers bufnr] insert-at-cursor key))

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -1,8 +1,8 @@
 (ns saya.modules.input.insert
   (:require
    [saya.cli.text-input.helpers :refer [dec-to-zero split-text-by-state]]
-   [saya.modules.input.helpers :refer [current-buffer-eol-col]]
-   [saya.modules.input.normal :refer [to-start-of-line]]))
+   [saya.modules.input.normal :refer [to-end-of-line to-start-of-line
+                                      update-cursor]]))
 
 (defn- line->string [line]
   (->> line
@@ -18,13 +18,12 @@
                     f
                     (fnil line->string []))))))
 
-(defn to-after-end-of-line [{:keys [buffer]}]
-  {:buffer (assoc-in buffer [:cursor :col]
-                     (current-buffer-eol-col buffer))})
-
 (def movement-keymaps
   {[:ctrl/a] to-start-of-line
-   [:ctrl/e] to-after-end-of-line})
+   [:ctrl/e] to-end-of-line
+
+   [:left] (update-cursor :col dec)
+   [:right] (update-cursor :col inc)})
 
 (defn backspace [{:keys [buffer] :as context}]
   (-> context

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -2,12 +2,16 @@
   (:require
    [clojure.string :as str]
    [saya.modules.ansi.split :as split]
-   [saya.modules.input.normal :refer [to-end-of-line to-start-of-line]]))
+   [saya.modules.input.helpers :refer [current-buffer-eol-col]]
+   [saya.modules.input.normal :refer [to-start-of-line]]))
+
+(defn to-after-end-of-line [{:keys [buffer]}]
+  {:buffer (assoc-in buffer [:cursor :col]
+                     (current-buffer-eol-col buffer))})
 
 (def movement-keymaps
   {[:ctrl/a] to-start-of-line
-   ; FIXME: actually go *after* eol
-   [:ctrl/e] to-end-of-line})
+   [:ctrl/e] to-after-end-of-line})
 
 ; TODO: basic delete keymaps like :delete
 

--- a/src/cli/saya/modules/input/keymaps.cljs
+++ b/src/cli/saya/modules/input/keymaps.cljs
@@ -40,5 +40,24 @@
       (def last-exception e)
       {:fx [(log-fx "ERROR performing" f ":" e)]})))
 
+(defn maybe-perform-with-keymap-buffer [& {:keys [keymaps keymap-buffer cofx
+                                                  with-unhandled key]
+                                           :or {with-unhandled identity}}]
+  (let [new-buffer ((fnil conj []) keymap-buffer key)
+        keymap (get keymaps new-buffer)
+        {:keys [db]} cofx]
+    (cond
+      keymap
+      (perform cofx keymap)
+
+      (possible? db :insert new-buffer)
+      {:db (assoc db :keymap-buffer new-buffer)}
+
+      :else
+      (-> cofx
+          (update :db dissoc :keymap-buffer)
+          (with-unhandled)
+          (select-keys [:db])))))
+
 (comment
   (println (.-stack last-exception)))

--- a/src/cli/saya/modules/input/keymaps.cljs
+++ b/src/cli/saya/modules/input/keymaps.cljs
@@ -1,5 +1,6 @@
 (ns saya.modules.input.keymaps
   (:require
+   [saya.modules.input.helpers :refer [*mode*]]
    [saya.modules.input.normal :as normal]
    [saya.modules.logging.core :refer [log-fx]]))
 
@@ -41,23 +42,24 @@
       {:fx [(log-fx "ERROR performing" f ":" e)]})))
 
 (defn maybe-perform-with-keymap-buffer [& {:keys [keymaps keymap-buffer cofx
-                                                  with-unhandled key]
+                                                  mode with-unhandled key]
                                            :or {with-unhandled identity}}]
-  (let [new-buffer ((fnil conj []) keymap-buffer key)
-        keymap (get keymaps new-buffer)
-        {:keys [db]} cofx]
-    (cond
-      keymap
-      (perform cofx keymap)
+  (binding [*mode* mode]
+    (let [new-buffer ((fnil conj []) keymap-buffer key)
+          keymap (get keymaps new-buffer)
+          {:keys [db]} cofx]
+      (cond
+        keymap
+        (perform cofx keymap)
 
-      (possible? db :insert new-buffer)
-      {:db (assoc db :keymap-buffer new-buffer)}
+        (possible? db :insert new-buffer)
+        {:db (assoc db :keymap-buffer new-buffer)}
 
-      :else
-      (-> cofx
-          (update :db dissoc :keymap-buffer)
-          (with-unhandled)
-          (select-keys [:db])))))
+        :else
+        (-> cofx
+            (update :db dissoc :keymap-buffer)
+            (with-unhandled)
+            (select-keys [:db]))))))
 
 (comment
   (println (.-stack last-exception)))

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -6,7 +6,7 @@
                                        current-buffer-line-last-col
                                        last-buffer-row]]))
 
-(defn- update-cursor [col-or-row f]
+(defn update-cursor [col-or-row f]
   (comp
    clamp-scroll
    adjust-scroll-to-cursor

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -23,12 +23,16 @@
      (assoc-in ctx [:buffer :cursor :row]
                (last-buffer-row buffer)))))
 
+(defn to-start-of-line [{:keys [buffer]}]
+  {:buffer (assoc-in buffer [:cursor :col] 0)})
+
+(defn to-end-of-line [{:keys [buffer]}]
+  {:buffer (assoc-in buffer [:cursor :col]
+                     (current-buffer-line-last-col buffer))})
+
 (def movement-keymaps
-  {["0"] (fn to-start-of-line [{:keys [buffer]}]
-           {:buffer (assoc-in buffer [:cursor :col] 0)})
-   ["$"] (fn to-end-of-line [{:keys [buffer]}]
-           {:buffer (assoc-in buffer [:cursor :col]
-                              (current-buffer-line-last-col buffer))})
+  {["0"] to-start-of-line
+   ["$"] to-end-of-line
 
    ["g" "g"] (comp
               clamp-scroll

--- a/src/cli/saya/modules/ui/cursor.cljs
+++ b/src/cli/saya/modules/ui/cursor.cljs
@@ -1,7 +1,6 @@
 (ns saya.modules.ui.cursor
   (:require
    ["ink" :as k]
-   ["react" :as React]
    ["strip-ansi" :default strip-ansi]
    [clojure.string :as str]))
 
@@ -35,11 +34,10 @@
   (str/replace s cursor-text ""))
 
 (defn- f>cursor [shape]
-  (React/useEffect
-   (fn []
-     (reset! shape-ref shape)
+  ; HACKS: This should *really* be a useLayoutEffect, but
+  ; that doesn't seem to consistently happen in time...?
+  (reset! shape-ref shape)
 
-     js/undefined))
   [:> k/Text cursor-text])
 
 (defn cursor

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -52,12 +52,13 @@
         line (or (seq line)
                  [""])]
     [:> k/Box {:min-height 0
-               :min-width 0
                :width :100%
                :flex-wrap (when input-connr :wrap)
                :align-items :left}
      [:> k/Box {:height 1
-                :flex-shrink 0}
+                :flex-shrink 0
+                :flex-direction :column
+                :width :100%}
       [:> k/Text {:wrap :truncate-end}
        (for [[i part] (map-indexed vector (or (seq line)
                                               [""]))]

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -67,7 +67,11 @@
             [cursor cursor-type])
           (if (vector? part)
             (into [(system-messages (first part))] (rest part))
-            [:> k/Text part])])]]
+            [:> k/Text part])])
+
+       ; cursor at eol
+       (when (= cursor-col (count line))
+         [cursor cursor-type])]]
      (when input-connr
        [input-window input-connr])]))
 

--- a/src/test/saya/modules/input/insert_test.cljs
+++ b/src/test/saya/modules/input/insert_test.cljs
@@ -1,0 +1,37 @@
+(ns saya.modules.input.insert-test
+  (:require
+   [cljs.test :refer-macros [deftest is testing]]
+   [saya.db :refer [default-db]]
+   [saya.modules.buffers.events :as buffer-events]
+   [saya.modules.input.insert :refer [insert-at-buffer]]
+   [saya.modules.input.test-helpers :refer [str->buffer]]))
+
+(defn create-cofx
+  ([] (create-cofx {}))
+  ([& {:keys [buffer]}]
+   (let [[db {created-buffer :buffer}] (-> default-db
+                                           (buffer-events/create-blank))
+         bufnr (:id created-buffer)]
+     {:db (cond-> db
+            buffer (update-in [:buffers bufnr] merge (str->buffer buffer)))
+      :bufnr bufnr})))
+
+(defn- get-buffer
+  ([cofx] (get-buffer cofx 0))
+  ([cofx id]
+   (-> (get-in cofx [:db :buffers id])
+       (dissoc :id))))
+
+(deftest insert-key-at-buffer-test
+  (testing "Insert key into empty buffer"
+    (let [cofx (create-cofx)
+          cofx' (insert-at-buffer cofx "f")]
+      (is (= (str->buffer "f|")
+             (get-buffer cofx')))))
+
+  (testing "Insert key at end of first line"
+    (let [cofx (create-cofx :buffer "f|")
+          cofx' (insert-at-buffer cofx "o")]
+      (is (= (str->buffer "fo|")
+             (get-buffer cofx'))))))
+

--- a/src/test/saya/modules/input/test_helpers.cljs
+++ b/src/test/saya/modules/input/test_helpers.cljs
@@ -15,7 +15,7 @@
             cursor-col (str/index-of line "|")]
         (recur (next raw-lines)
                indent
-               (conj lines (str/replace line #"|" ""))
+               (conj lines (str/replace line #"\|" ""))
                (cond
                  cursor-col
                  (assoc cursor :col cursor-col)
@@ -31,10 +31,10 @@
 
 (defn str->buffer [s]
   (let [[lines cursor] (extract-lines-and-cursor s)]
-    {:lines (map (fn [line-str]
-                   {:ansi line-str
-                    :plain line-str})
-                 lines)
+    {:lines (mapv (fn [line-str]
+                    [{:ansi line-str
+                      :plain line-str}])
+                  lines)
      :cursor cursor}))
 
 (defn make-context [& {:keys [buffer window]}]


### PR DESCRIPTION
This also gives us basic insert-mode editing in command-line windows! Eventually we'll want to add support for reading text files into buffers, for note taking.

- **Prepare rough support for creating a blank non-connection buffer**
- **Add basic support for insert-mode typing and keymaps**
- **Fix ctrl/e going *onto* last column of line, instead of after**
- **(Hopefully) fix buffer lines truncating too eagerly**
- **Add :backspace support + add a nice keymap unit test helper**
- **Support arrow nav in insert mode + tweak eol handling for reuse**
- **Fix: cursor shape not updating in time for render**
- **Cleanup/share exit-insert-mode code**
- **Perform some light code cleanup**
- **Clean up unused import**
