### PR TITLE
Significantly improve scrolling + add tests

### DIFF
--- a/src/cli/saya/cli.cljs
+++ b/src/cli/saya/cli.cljs
@@ -12,9 +12,10 @@
    [saya.util.ink :as ink]
    [saya.views :as views]
 
-   ; NOTE: Required here just to convince shadow to build it in dev
-   ; Ideally we can strip this from prod builds...
-   [saya.util.ink-testing-utils]))
+   ; NOTE: Required here just to convince shadow to build them in dev
+   ; Ideally we can strip these from prod builds...
+   [saya.util.ink-testing-utils]
+   [saya.modules.input.test-helpers]))
 
 (defonce ^:private ink-instance (atom nil))
 

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -16,6 +16,7 @@
       (trim-suffix "\u001B[0m")))
 
 (defn wrap-ansi [s width]
+  {:pre [(number? width)]}
   (loop [lines []
          current-line []
          current-line-width 0

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -3,8 +3,7 @@
    ["ansi-parser" :default AnsiParser]
    [applied-science.js-interop :as j]
    [saya.modules.ansi.split :as split]
-   [saya.modules.ansi.wrap :refer [wrap-ansi]]
-   [re-frame.core :as re-frame]))
+   [saya.modules.ansi.wrap :refer [wrap-ansi]]))
 
 (defn- ->ansi-chars [parts]
   (->> parts

--- a/src/cli/saya/modules/buffers/util.cljs
+++ b/src/cli/saya/modules/buffers/util.cljs
@@ -1,7 +1,6 @@
 (ns saya.modules.buffers.util
   (:require
-   [saya.modules.buffers.line :refer [length]]
-   [saya.modules.input.insert :refer [line->string]]))
+   [saya.modules.buffers.line :refer [length]]))
 
 (defn readonly? [buffer]
   (some?
@@ -16,9 +15,29 @@
   ([{:keys [cursor] :as buffer}] (char-at buffer cursor))
   ([{:keys [lines]} {:keys [row col]}]
    (when (<= 0 row (dec (count lines)))
-     (let [line (line->string (nth lines row))]
+     (let [line (str (nth lines row))]
        (when (<= 0 col (dec (count line)))
          (.charAt line col))))))
+
+(defn clamp-cursor
+  ([cursor [min-cursor max-cursor]] (clamp-cursor cursor min-cursor max-cursor))
+  ([cursor min-cursor max-cursor]
+   (cond
+     (< (:row cursor) (:row min-cursor))
+     min-cursor
+
+     (and (= (:row cursor) (:row min-cursor))
+          (< (:col cursor) (:col min-cursor)))
+     min-cursor
+
+     (> (:row cursor) (:row max-cursor))
+     max-cursor
+
+     (and (= (:row cursor) (:row max-cursor))
+          (> (:col cursor) (:col max-cursor)))
+     max-cursor
+
+     :else cursor)))
 
 (defn update-cursor
   ([{:keys [cursor] :as buffer} pred]

--- a/src/cli/saya/modules/input/helpers.cljs
+++ b/src/cli/saya/modules/input/helpers.cljs
@@ -58,7 +58,7 @@
                        (last-buffer-row buffer))
         min-cursor-row (max 0 (inc (- anchor-row height)))
         max-cursor-row (min (last-buffer-row buffer)
-                            (+ min-cursor-row height))]
+                            (+ min-cursor-row (dec height)))]
     (update-in ctx [:buffer :cursor :row]
                #(min max-cursor-row
                      (max min-cursor-row %)))))

--- a/src/cli/saya/modules/input/helpers.cljs
+++ b/src/cli/saya/modules/input/helpers.cljs
@@ -1,8 +1,13 @@
 (ns saya.modules.input.helpers
   (:require
-   [saya.modules.buffers.line :refer [ansi-chars]]))
+   [saya.cli.text-input.helpers :refer [dec-to-zero]]
+   [saya.modules.buffers.line :refer [ansi-chars wrapped-lines]]))
 
 (def ^:dynamic *mode* :normal)
+
+(defn- nil-or-zero? [v]
+  (or (nil? v)
+      (= 0 v)))
 
 (defn current-buffer-line [{:keys [lines cursor]}]
   (->> (nth lines (:row cursor))
@@ -22,9 +27,10 @@
            (dec after-last-col)))))
 
 (defn clamp-scroll [{:keys [window buffer] :as ctx}]
-  (let [{:keys [height anchor-row]} window]
+  (let [{:keys [height anchor-offset anchor-row]} window]
     (cond
-      (>= anchor-row (last-buffer-row buffer))
+      (and (>= anchor-row (last-buffer-row buffer))
+           (nil-or-zero? anchor-offset))
       (update ctx :window dissoc :anchor-row)
 
       (and anchor-row
@@ -35,12 +41,13 @@
       :else ctx)))
 
 (defn adjust-scroll-to-cursor [{:keys [buffer window] :as ctx}]
-  (let [{:keys [height anchor-row]} window
+  (let [{:keys [height anchor-offset anchor-row]} window
         {:keys [row]} (:cursor buffer)
         anchor-row (or anchor-row
                        (last-buffer-row buffer))]
     (cond
-      (>= row (last-buffer-row buffer))
+      (and (>= row (last-buffer-row buffer))
+           (nil-or-zero? anchor-offset))
       (update ctx :window dissoc :anchor-row)
 
       (<= row (- anchor-row height))
@@ -53,15 +60,29 @@
       :else ctx)))
 
 (defn adjust-cursor-to-scroll [{:keys [window buffer] :as ctx}]
-  (let [{:keys [height anchor-row]} window
+  (let [{:keys [height width anchor-offset anchor-row]} window
         anchor-row (or anchor-row
                        (last-buffer-row buffer))
         min-cursor-row (max 0 (inc (- anchor-row height)))
         max-cursor-row (min (last-buffer-row buffer)
-                            (+ min-cursor-row (dec height)))]
-    (update-in ctx [:buffer :cursor :row]
-               #(min max-cursor-row
-                     (max min-cursor-row %)))))
+                            (+ min-cursor-row (dec height)))
+        {:keys [col row]} (:cursor buffer)
+        row' (min max-cursor-row
+                  (max min-cursor-row row))
+        wrapped (wrapped-lines
+                 (get-in buffer [:lines row])
+                 width)]
+    (cond-> (assoc-in ctx [:buffer :cursor :row] row')
+      ; Adjust :col to be within the visible part of the line
+      (= anchor-row row)
+      (as-> ctx
+        (let [visible-lines (drop-last anchor-offset wrapped)
+              last-visible-col (dec-to-zero
+                                (+ (:col (last visible-lines))
+                                   (count (last visible-lines))))]
+          (cond-> ctx
+            (> col last-visible-col)
+            (assoc-in [:buffer :cursor :col] last-visible-col)))))))
 
 (defn clamp-cursor [{:keys [window buffer] :as ctx}]
   (let [{:keys [height anchor-row]} window

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -29,7 +29,6 @@
    ["$"] #'to-end-of-line
 
    ["g" "g"] (comp
-              clamp-scroll
               adjust-scroll-to-cursor
               (fn to-first-line [ctx]
                 (assoc-in ctx [:buffer :cursor] {:col 0
@@ -114,10 +113,10 @@
 
 (defn update-scroll [f compute-amount]
   (comp
-   adjust-scroll-to-cursor
+   ; adjust-scroll-to-cursor
    adjust-cursor-to-scroll
-   clamp-cursor
-   clamp-scroll
+   ; clamp-cursor
+   ; clamp-scroll
    (fn scroll-updater [{:keys [buffer window] :as ctx}]
      (loop [anchor-row (:anchor-row window (last-buffer-row buffer))
             anchor-offset (:anchor-offset window 0)

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -1,5 +1,7 @@
 (ns saya.modules.input.normal
   (:require
+   [saya.cli.text-input.helpers :refer [dec-to-zero]]
+   [saya.modules.buffers.line :refer [wrapped-lines]]
    [saya.modules.buffers.util :as buffers]
    [saya.modules.input.helpers :refer [adjust-cursor-to-scroll
                                        adjust-scroll-to-cursor clamp-cursor
@@ -116,10 +118,42 @@
    adjust-cursor-to-scroll
    clamp-cursor
    clamp-scroll
-   (fn scroll-updater [{:keys [buffer] :as ctx}]
-     (update-in ctx [:window :anchor-row]
-                (fnil f (last-buffer-row buffer))
-                (compute-amount ctx)))))
+   (fn scroll-updater [{:keys [buffer window] :as ctx}]
+     (loop [anchor-row (:anchor-row window (last-buffer-row buffer))
+            anchor-offset (:anchor-offset window 0)
+            scroll-to-consume (compute-amount ctx)]
+       (let [available-lines (count
+                              (wrapped-lines
+                               (get-in buffer [:lines anchor-row])
+                               (:width window)))
+             max-anchor-offset (dec-to-zero available-lines)
+             available-lines (- available-lines
+                                anchor-offset)
+             next-anchor-offset (f anchor-offset
+                                   (* -1 scroll-to-consume))]
+         (cond
+           (and (> available-lines 0)
+                (<= 0 next-anchor-offset max-anchor-offset)
+                (<= scroll-to-consume available-lines))
+           (update ctx :window assoc
+                   :anchor-row anchor-row
+                   :anchor-offset next-anchor-offset)
+
+           (or (= 0 scroll-to-consume)
+               (let [next-row (f anchor-row 1)]
+                 (or (> next-row (last-buffer-row buffer))
+                     (< next-row 0))))
+           (update ctx :window assoc
+                   :anchor-row anchor-row
+                   :anchor-offset anchor-offset)
+
+           :else
+           (recur
+            (f anchor-row 1)
+            ; TODO: Actually if scrolling forward this probably should be
+            ; (dec full-available-lines), I think
+            0
+            (- scroll-to-consume available-lines))))))))
 
 (defn- window-rows [{:keys [window]}]
   ; Actually a page is 2 less than the window height

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -110,7 +110,7 @@
 
 ; ======= Scroll keymaps ===================================
 
-(defn- update-scroll [f compute-amount]
+(defn update-scroll [f compute-amount]
   (comp
    adjust-scroll-to-cursor
    adjust-cursor-to-scroll
@@ -122,6 +122,7 @@
                 (compute-amount ctx)))))
 
 (defn- window-rows [{:keys [window]}]
+  ; Actually a page is 2 less than the window height
   (dec (:height window)))
 
 (def scroll-keymaps

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -24,16 +24,18 @@
      (assoc-in ctx [:buffer :cursor :row]
                (last-buffer-row buffer)))))
 
+(def scroll-to-top
+  (comp
+   adjust-scroll-to-cursor
+   (fn to-first-line [ctx]
+     (assoc-in ctx [:buffer :cursor] {:col 0
+                                      :row 0}))))
+
 (def movement-keymaps
   {["0"] #'to-start-of-line
    ["$"] #'to-end-of-line
 
-   ["g" "g"] (comp
-              adjust-scroll-to-cursor
-              (fn to-first-line [ctx]
-                (assoc-in ctx [:buffer :cursor] {:col 0
-                                                 :row 0})))
-
+   ["g" "g"] #'scroll-to-top
    ["G"] #'scroll-to-bottom
 
    ; Single char movement

--- a/src/test/saya/modules/input/helpers_test.cljs
+++ b/src/test/saya/modules/input/helpers_test.cljs
@@ -110,7 +110,7 @@
        say it |anyway"
       "Talkin
        away I
-       don't know what I'm to| say I'll
+       don't know what |I'm to say I'll
        say it anyway"
       :window {:height 4 :width 10}
       :window-expect {:anchor-row 2 :anchor-offset 1})))

--- a/src/test/saya/modules/input/helpers_test.cljs
+++ b/src/test/saya/modules/input/helpers_test.cljs
@@ -3,7 +3,9 @@
    [clojure.test :refer [deftest is testing]]
    [saya.modules.input.helpers :refer [adjust-scroll-to-cursor
                                        derive-anchor-from-top-cursor]]
-   [saya.modules.input.test-helpers :refer [make-context]]))
+   [saya.modules.input.normal :refer [scroll-to-top]]
+   [saya.modules.input.test-helpers :refer [make-context
+                                            with-keymap-compare-buffer]]))
 
 (defn derive-anchor-from-top-cursor' [{:keys [buffer window]}]
   (derive-anchor-from-top-cursor
@@ -84,4 +86,17 @@
                :window {:height 2 :width 30})
           ctx' (adjust-scroll-to-cursor ctx)]
       (is (= 1 (:anchor-row (:window ctx'))))
-      (is (= 0 (:anchor-offset (:window ctx')))))))
+      (is (= 0 (:anchor-offset (:window ctx'))))))
+
+  (testing "Scroll to top, tall window"
+    (with-keymap-compare-buffer scroll-to-top
+      "Talkin
+       away I
+       don't know what I'm to say I'll
+       say it |anyway"
+      "|Talkin
+       away I
+       don't know what I'm to say I'll
+       say it anyway"
+      :window {:height 7 :width 10}
+      :window-expect {:anchor-row 3 :anchor-offset 1})))

--- a/src/test/saya/modules/input/helpers_test.cljs
+++ b/src/test/saya/modules/input/helpers_test.cljs
@@ -14,4 +14,36 @@
           ctx' (adjust-scroll-to-cursor ctx)]
       (is (nil? (:anchor-row (:window ctx'))))
       (is (= {:row 2 :col 0}
-             (:cursor (:buffer ctx')))))))
+             (:cursor (:buffer ctx'))))))
+
+  (testing "Scroll to top, wrapped"
+    (let [ctx (make-context
+               :buffer "|Talkin away I don't know
+                        what I'm to say
+                        I'll say it anyway"
+               :window {:height 2 :width 10})
+          ctx' (adjust-scroll-to-cursor ctx)]
+      (is (= 0 (:anchor-row (:window ctx'))))
+      (is (= 1 (:anchor-offset (:window ctx'))))))
+
+  (testing "Scroll to top, mixed-wrapped"
+    (let [ctx (make-context
+               :buffer "|Talkin
+                        away I
+                        don't know
+                        what I'm to say I'll
+                        say it anyway"
+               :window {:height 2 :width 10})
+          ctx' (adjust-scroll-to-cursor ctx)]
+      (is (= 1 (:anchor-row (:window ctx'))))
+      (is (= 0 (:anchor-offset (:window ctx'))))))
+
+  (testing "Scroll to top, non wrapped"
+    (let [ctx (make-context
+               :buffer "|Talkin away I don't know
+                        what I'm to say
+                        I'll say it anyway"
+               :window {:height 2 :width 30})
+          ctx' (adjust-scroll-to-cursor ctx)]
+      (is (= 1 (:anchor-row (:window ctx'))))
+      (is (= 0 (:anchor-offset (:window ctx')))))))

--- a/src/test/saya/modules/input/helpers_test.cljs
+++ b/src/test/saya/modules/input/helpers_test.cljs
@@ -3,7 +3,7 @@
    [clojure.test :refer [deftest is testing]]
    [saya.modules.input.helpers :refer [adjust-scroll-to-cursor
                                        derive-anchor-from-top-cursor]]
-   [saya.modules.input.normal :refer [scroll-to-top]]
+   [saya.modules.input.normal :refer [scroll-to-top update-scroll]]
    [saya.modules.input.test-helpers :refer [make-context
                                             with-keymap-compare-buffer]]))
 
@@ -100,3 +100,17 @@
        say it anyway"
       :window {:height 7 :width 10}
       :window-expect {:anchor-row 3 :anchor-offset 1})))
+
+(deftest adjust-cursor-to-scroll-test
+  (testing "Handle wrapped lines"
+    (with-keymap-compare-buffer (update-scroll - (constantly 3))
+      "Talkin
+       away I
+       don't know what I'm to say I'll
+       say it |anyway"
+      "Talkin
+       away I
+       don't know what I'm to| say I'll
+       say it anyway"
+      :window {:height 4 :width 10}
+      :window-expect {:anchor-row 2 :anchor-offset 1})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -132,15 +132,15 @@
   (testing "Move cursor up with wrapped lines"
     (with-keymap-compare-buffer (update-scroll - (constantly 1))
       "For the honor of |Grayskull!"
-      "For the h|onor of Grayskull!"
+      "For the |honor of Grayskull!"
       :window {:height 1 :width 10}
       :window-expect {:height 1 :width 10
                       :anchor-row 0
                       :anchor-offset 1})
 
     (with-keymap-compare-buffer (update-scroll - (constantly 1))
-      "For the h|onor of Grayskull!"
-      "F|or the honor of Grayskull!"
+      "For the |honor of Grayskull!"
+      "|For the honor of Grayskull!"
       :window {:height 1 :width 10
                :anchor-row 0
                :anchor-offset 1}

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -1,7 +1,7 @@
 (ns saya.modules.input.normal-test
   (:require
    [cljs.test :refer-macros [deftest testing]]
-   [saya.modules.input.normal :refer [delete-operator]]
+   [saya.modules.input.normal :refer [delete-operator update-scroll]]
    [saya.modules.input.test-helpers :refer [with-keymap-compare-buffer]]))
 
 (deftest delete-operator-test
@@ -58,3 +58,67 @@
       "For the honor of Grayskull|!"
       "For the honor of Grayskull|")))
 
+(deftest scroll-test
+  (testing "Scroll up single lines"
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "For the
+       honor of
+       |Grayskull!"
+      "For the
+       |honor of
+       Grayskull!"
+      :window {:height 1}
+      :window-expect {:height 1 :anchor-row 1})
+
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "For the
+       |honor of
+       Grayskull!"
+      "|For the
+       honor of
+       Grayskull!"
+      :window {:height 1 :anchor-row 1}
+      :window-expect {:height 1 :anchor-row 0})
+
+    ; no-op at the top
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "|For the
+       honor of
+       Grayskull!"
+      "|For the
+       honor of
+       Grayskull!"
+      :window {:height 1 :anchor-row 0}
+      :window-expect {:height 1 :anchor-row 0}))
+
+  (testing "Scroll down single lines"
+    (with-keymap-compare-buffer (update-scroll + (constantly 1))
+      "|For the
+       honor of
+       Grayskull!"
+      "For the
+       |honor of
+       Grayskull!"
+      :window {:height 1 :anchor-row 0}
+      :window-expect {:height 1 :anchor-row 1})
+
+    (with-keymap-compare-buffer (update-scroll + (constantly 1))
+      "For the
+       |honor of
+       Grayskull!"
+      "For the
+       honor of
+       |Grayskull!"
+      :window {:height 1 :anchor-row 1}
+      :window-expect {:height 1})
+
+    ; no-op at the bottom
+    (with-keymap-compare-buffer (update-scroll + (constantly 1))
+      "For the
+       honor of
+       |Grayskull!"
+      "For the
+       honor of
+       |Grayskull!"
+      :window {:height 1}
+      :window-expect {:height 1})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -68,7 +68,7 @@
       "For the
        |honor of
        Grayskull!"
-      :window {:height 1}
+      :window {:height 1 :width 10}
       :window-expect {:height 1 :anchor-row 1})
 
     (with-keymap-compare-buffer (update-scroll - (constantly 1))
@@ -78,7 +78,8 @@
       "|For the
        honor of
        Grayskull!"
-      :window {:height 1 :anchor-row 1}
+      :window {:height 1 :width 10
+               :anchor-row 1}
       :window-expect {:height 1 :anchor-row 0})
 
     ; no-op at the top
@@ -89,7 +90,8 @@
       "|For the
        honor of
        Grayskull!"
-      :window {:height 1 :anchor-row 0}
+      :window {:height 1 :width 10
+               :anchor-row 0}
       :window-expect {:height 1 :anchor-row 0}))
 
   (testing "Scroll down single lines"
@@ -100,7 +102,8 @@
       "For the
        |honor of
        Grayskull!"
-      :window {:height 1 :anchor-row 0}
+      :window {:height 1 :width 10
+               :anchor-row 0}
       :window-expect {:height 1 :anchor-row 1})
 
     (with-keymap-compare-buffer (update-scroll + (constantly 1))
@@ -110,7 +113,8 @@
       "For the
        honor of
        |Grayskull!"
-      :window {:height 1 :anchor-row 1}
+      :window {:height 1 :width 10
+               :anchor-row 1}
       :window-expect {:height 1})
 
     ; no-op at the bottom
@@ -121,8 +125,38 @@
       "For the
        honor of
        |Grayskull!"
-      :window {:height 1}
+      :window {:height 1 :width 10}
       :window-expect {:height 1})))
+
+(deftest wrapped-scroll-test
+  (testing "Move cursor up with wrapped lines"
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "For the honor of |Grayskull!"
+      "For the h|onor of Grayskull!"
+      :window {:height 1 :width 10}
+      :window-expect {:height 1 :width 10
+                      :anchor-row 0
+                      :anchor-offset 1})
+
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "For the h|onor of Grayskull!"
+      "F|or the honor of Grayskull!"
+      :window {:height 1 :width 10
+               :anchor-row 0
+               :anchor-offset 1}
+      :window-expect {:height 1 :width 10
+                      :anchor-row 0
+                      :anchor-offset 2})
+
+    ; no-op at the top
+    (with-keymap-compare-buffer (update-scroll - (constantly 1))
+      "|For the honor of Grayskull!"
+      "|For the honor of Grayskull!"
+      :window {:height 1 :width 10
+               :anchor-row 0 :anchor-offset 2}
+      :window-expect {:height 1 :width 10
+                      :anchor-row 0
+                      :anchor-offset 2})))
 
 (deftest vertical-cursor-movement-test
   (testing "Move cursor up with single lines"
@@ -133,7 +167,7 @@
       "For the
        |honor of
        Grayskull!"
-      :window {:height 1}
+      :window {:height 1 :width 10}
       :window-expect {:height 1 :anchor-row 1})
 
     (with-keymap-compare-buffer (update-cursor :row dec)
@@ -143,7 +177,8 @@
       "|For the
        honor of
        Grayskull!"
-      :window {:height 1 :anchor-row 1}
+      :window {:height 1 :width 10
+               :anchor-row 1}
       :window-expect {:height 1 :anchor-row 0})
 
     ; no-op at the top
@@ -154,5 +189,7 @@
       "|For the
        honor of
        Grayskull!"
-      :window {:height 1 :anchor-row 0}
-      :window-expect {:height 1 :anchor-row 0})))
+      :window {:height 1 :width 10
+               :anchor-row 0}
+      :window-expect {:height 1 :width 10
+                      :anchor-row 0})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -192,4 +192,20 @@
       :window {:height 1 :width 10
                :anchor-row 0}
       :window-expect {:height 1 :width 10
-                      :anchor-row 0})))
+                      :anchor-row 0}))
+
+  (testing "Move cursor up with mixed lines"
+    (with-keymap-compare-buffer (update-cursor :row dec)
+      "Talkin
+       away I
+       |don't know
+       what I'm to say
+       I'll say it anyway"
+      "Talkin
+       |away I
+       don't know
+       what I'm to say
+       I'll say it anyway"
+      :window {:height 3 :width 10
+               :anchor-row 3 :anchor-offset 1}
+      :window-expect {:anchor-row 2 :anchor-offset 0})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -1,6 +1,7 @@
 (ns saya.modules.input.normal-test
   (:require
    [cljs.test :refer-macros [deftest testing]]
+   [saya.modules.input.helpers :refer [update-cursor]]
    [saya.modules.input.normal :refer [delete-operator update-scroll]]
    [saya.modules.input.test-helpers :refer [with-keymap-compare-buffer]]))
 
@@ -122,3 +123,36 @@
        |Grayskull!"
       :window {:height 1}
       :window-expect {:height 1})))
+
+(deftest vertical-cursor-movement-test
+  (testing "Move cursor up with single lines"
+    (with-keymap-compare-buffer (update-cursor :row dec)
+      "For the
+       honor of
+       |Grayskull!"
+      "For the
+       |honor of
+       Grayskull!"
+      :window {:height 1}
+      :window-expect {:height 1 :anchor-row 1})
+
+    (with-keymap-compare-buffer (update-cursor :row dec)
+      "For the
+       |honor of
+       Grayskull!"
+      "|For the
+       honor of
+       Grayskull!"
+      :window {:height 1 :anchor-row 1}
+      :window-expect {:height 1 :anchor-row 0})
+
+    ; no-op at the top
+    (with-keymap-compare-buffer (update-cursor :row dec)
+      "|For the
+       honor of
+       Grayskull!"
+      "|For the
+       honor of
+       Grayskull!"
+      :window {:height 1 :anchor-row 0}
+      :window-expect {:height 1 :anchor-row 0})))

--- a/src/test/saya/modules/input/test_helpers.cljs
+++ b/src/test/saya/modules/input/test_helpers.cljs
@@ -58,7 +58,7 @@
                (-> (buffer-events/create-blank default-db)
                    (second)
                    :buffer))
-   :window (merge {:height 2} window)})
+   :window (merge {:height 2 :width 20} window)})
 
 (defn get-buffer [ctx]
   (-> (get-in ctx [:buffer])

--- a/src/test/saya/modules/input/test_helpers.cljs
+++ b/src/test/saya/modules/input/test_helpers.cljs
@@ -64,8 +64,10 @@
   (-> (get-in ctx [:buffer])
       (select-keys [:lines :cursor])))
 
-(defn with-keymap-compare-buffer [f buffer-before buffer-after]
-  (let [ctx (make-context :buffer buffer-before)
+(defn with-keymap-compare-buffer
+  [f buffer-before buffer-after & {:keys [window window-expect]}]
+  (let [ctx (make-context :buffer buffer-before
+                          :window window)
         ctx' (try (f ctx)
                   (catch :default e
                     (println "ERROR performing " f ": " e)
@@ -74,4 +76,8 @@
         expected (buffer->str (get-buffer (make-context :buffer buffer-after)))
         actual (buffer->str (get-buffer ctx'))]
     (is (= expected actual)
-        (str "From " (buffer->str (get-buffer ctx)) "\n"))))
+        (str "From " (buffer->str (get-buffer ctx)) "\n"))
+
+    (when window-expect
+      (is (= window-expect (-> (get-in ctx' [:window])
+                               (select-keys (keys window-expect))))))))

--- a/src/test/saya/modules/input/test_helpers.cljs
+++ b/src/test/saya/modules/input/test_helpers.cljs
@@ -6,7 +6,8 @@
    [saya.db :refer [default-db]]
    [saya.modules.buffers.events :as buffer-events]
    [saya.modules.buffers.line :refer [buffer-line]]
-   [saya.modules.input.insert :refer [line->string]]))
+   [saya.modules.input.insert :refer [line->string]]
+   [saya.modules.window.subs :refer [visible-lines]]))
 
 (defn- extract-lines-and-cursor [s]
   (loop [raw-lines (str/split-lines s)
@@ -80,4 +81,16 @@
 
     (when window-expect
       (is (= window-expect (-> (get-in ctx' [:window])
-                               (select-keys (keys window-expect))))))))
+                               (select-keys (keys window-expect))))
+          (letfn [(vis' [ctx]
+                    (->> (visible-lines
+                          (:window ctx)
+                          (:lines (:buffer ctx)))
+                         (map (fn [{:keys [line]}]
+                                (str/join line)))))]
+            (str "Visible lines:\n"
+                 (vis' ctx)
+                 "\n -> \n"
+                 (vis' ctx')
+                 "\n Expected:\n"
+                 (vis' (update ctx :window merge window-expect))))))))

--- a/src/test/saya/modules/window/subs_test.cljs
+++ b/src/test/saya/modules/window/subs_test.cljs
@@ -7,8 +7,8 @@
 
 (deftest visible-lines-test
   (testing "No anchor row"
-    (is (= [{:row 1 :col 0 :line ["2"]}
-            {:row 2 :col 0 :line ["3"]}]
+    (is (= [{:row 1 :col 0 :line ["2"] :last-of-row? true}
+            {:row 2 :col 0 :line ["3"] :last-of-row? true}]
 
            (visible-lines
             {:height 2
@@ -19,8 +19,8 @@
              (buffer-line "3")]))))
 
   (testing "Anchor row"
-    (is (= [{:row 0 :col 0 :line ["1"]}
-            {:row 1 :col 0 :line ["2"]}]
+    (is (= [{:row 0 :col 0 :line ["1"] :last-of-row? true}
+            {:row 1 :col 0 :line ["2"] :last-of-row? true}]
 
            (visible-lines
             {:height 2
@@ -31,8 +31,8 @@
              (buffer-line "3")]))))
 
   (testing "Wrap words"
-    (is (= [{:row 0 :col 8 :line (str/split "honor of " "")}
-            {:row 0 :col 17 :line (str/split "grayskull" "")}]
+    (is (= [{:row 0 :col 8 :line (str/split "honor of " "") :last-of-row? false}
+            {:row 0 :col 17 :line (str/split "grayskull" "") :last-of-row? true}]
 
            (visible-lines
             {:height 2
@@ -41,8 +41,8 @@
             [(buffer-line "for the honor of grayskull")]))))
 
   (testing "Wrap words with anchor offset"
-    (is (= [{:row 0 :col 0 :line (str/split "for the " "")}
-            {:row 0 :col 8 :line (str/split "honor of " "")}]
+    (is (= [{:row 0 :col 0 :line (str/split "for the " "") :last-of-row? false}
+            {:row 0 :col 8 :line (str/split "honor of " "") :last-of-row? false}]
 
            (visible-lines
             {:height 2


### PR DESCRIPTION
As mentioned, there are still issues with scrolling, but this should at least get us to a usable state so we can move forward and take a break from scrolling.

Filed #10 and #11 as follow-ups

- **Fix basic single-line (and window) scrolling**
- **Add non-wrapped cursor movement tests**
- **Add initial refactor to handle scrolling through wrapped lines**
- **Update window.subs-test for the new prop**
- **Clean up unused import**
- **Refactor adjust-cursor-to-scroll to handle virtual lines**
- **Make adjust-scroll-to-cursor always handle virtual lines**
- **Perform adjust-scroll-to-cursor on window resize**
- **Add, update, and fix some tests**
- **Improve the test helper with more context on errors**
- ***Finally* find a repro for scroll-to-top not working**
- **Fix the off-by-one in derive-anchor-from-top-cursor**
