### PR TITLE
Scaffold basic support for scripting

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,4 +5,10 @@
  :lint-as {applied-science.js-interop/defn clojure.core/defn
            applied-science.js-interop/let clojure.core/let
            applied-science.js-interop/fn clojure.core/fn
-           reagent.core/with-let clojure.core/let}}
+           reagent.core/with-let clojure.core/let}
+
+ :ns-groups [{:pattern "saya\\.modules\\.scripting\\..*" :name scripting-group}]
+
+ ; NOTE: This is not actually respected by clojure-lsp... yet
+ :config-in-ns {scripting-group {:ignore [:clojure-lsp/unused-public-var
+                                          clojure-lsp/unused-public-var]}}}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-dom": "^18.3.1",
     "split2": "^4.2.0",
     "string-width": "^7.2.0",
-    "strip-ansi": "^7.1.0"
+    "strip-ansi": "^7.1.0",
+    "untildify": "^5.0.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
+      untildify:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       shadow-cljs:
         specifier: ^2.28.20
@@ -574,6 +577,10 @@ packages:
 
   type-fest@4.33.0:
     resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
+    engines: {node: '>=16'}
+
+  untildify@5.0.0:
+    resolution: {integrity: sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==}
     engines: {node: '>=16'}
 
   url@0.11.4:
@@ -1255,6 +1262,8 @@ snapshots:
   tty-browserify@0.0.0: {}
 
   type-fest@4.33.0: {}
+
+  untildify@5.0.0: {}
 
   url@0.11.4:
     dependencies:

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -19,7 +19,7 @@
                 ; ::inject/sub cofx (for subscriptions in event handlers)
                 [re-frame-utils "0.1.0"]
 
-                [org.babashka/sci "0.8.43"]
+                [org.babashka/sci "0.9.44"]
 
                 ; etc:
                 [alandipert/storage-atom "2.0.1"]

--- a/src/cli/saya/cli/args.cljs
+++ b/src/cli/saya/cli/args.cljs
@@ -1,5 +1,37 @@
-(ns saya.cli.args)
+(ns saya.cli.args
+  (:require
+   ["node:fs" :rename {existsSync exists-sync?}]
+   [clojure.string :as str]
+   [saya.util.paths :as paths]))
+
+(def help
+  (->> ["usage: saya [<uri>]"
+        ""
+        "options:"
+        "   uri: Either a path to a script file or a"
+        "        host:port to connect to."]
+       (str/join "\n")))
 
 (defn parse-cli-args [args]
-  ; TODO:
-  {:raw args})
+  (when (some #{"--help"} args)
+    (println help)
+    (js/process.exit 0))
+
+  (let [before-node (drop-while
+                     (fn [p]
+                       (not (str/ends-with? p "node")))
+                     args)
+        args (if (seq before-node)
+               (drop 2 before-node)
+               (drop 1 args))
+        uri (first args)]
+    (if (and (some? uri)
+             (str/includes? uri ":"))
+      [:connect uri]
+
+      (if (exists-sync? (paths/resolve-user uri))
+        [:load-script uri]
+
+        (do
+          (println "saya: No such script file: " uri)
+          (js/process.exit 1))))))

--- a/src/cli/saya/cli/args.cljs
+++ b/src/cli/saya/cli/args.cljs
@@ -13,7 +13,7 @@
        (str/join "\n")))
 
 (defn parse-cli-args [args]
-  (when (some #{"--help"} args)
+  (when (some #{"--help" "help"} args)
     (println help)
     (js/process.exit 0))
 
@@ -25,13 +25,17 @@
                (drop 2 before-node)
                (drop 1 args))
         uri (first args)]
-    (if (and (some? uri)
-             (str/includes? uri ":"))
+    (cond
+      (not (string? uri))
+      nil
+
+      (str/includes? uri ":")
       [:connect uri]
 
-      (if (exists-sync? (paths/resolve-user uri))
-        [:load-script uri]
+      (exists-sync? (paths/resolve-user uri))
+      [:load-script uri]
 
-        (do
-          (println "saya: No such script file: " uri)
-          (js/process.exit 1))))))
+      :else
+      (do
+        (println "saya: No such script file: " uri)
+        (js/process.exit 1)))))

--- a/src/cli/saya/db.cljs
+++ b/src/cli/saya/db.cljs
@@ -10,7 +10,7 @@
    :buffers {}
    :windows {}
 
-   :connection->bufnr {}
+   :connections {}
 
    :current-winnr nil
    :next-bufnr 0

--- a/src/cli/saya/env.cljs
+++ b/src/cli/saya/env.cljs
@@ -2,8 +2,9 @@
   (:require
    ["node:fs/promises" :as fs]
    [promesa.core :as p]
+   [saya.modules.logging.core :refer [log]]
+   [saya.modules.scripting.core :as scripting-core]
    [saya.util.paths :as paths]
-   [saya.modules.scripting.core]
    [sci.core :as sci]))
 
 (def ^:private saya-core-ns
@@ -11,7 +12,14 @@
     (sci/copy-ns saya.modules.scripting.core core-ns)))
 
 (def ^:private context-opts {:namespaces
-                             {'saya.core saya-core-ns}})
+                             {'saya.core saya-core-ns}
+
+                             ; Convenience to convert `#send "string"` into
+                             ; a mapping that sends "string" to the connection
+                             :readers
+                             {'send (fn [text]
+                                      (fn do-send [conn]
+                                        (scripting-core/send conn text)))}})
 
 (defn- read-init []
   (-> (p/let [init-path (paths/user-config "init.clj")
@@ -43,7 +51,7 @@
                 (symbol ns-sym sym))))))
 
 (defn- eval-script [ctx {:keys [first-load?]} script-string]
-  (let [{:keys [ns]} (sci/eval-string+ ctx script-string)
+  (let [{:keys [ns val]} (sci/eval-string+ ctx script-string)
 
         ; Check if a -main was declared
         main-result (when first-load?
@@ -62,7 +70,8 @@
 
     {:ns ns
      :main main-result
-     :after-load after-load}))
+     :after-load after-load
+     :val val}))
 
 ; TODO: Remove these
 (defonce ^:private current-context (atom nil))
@@ -78,6 +87,7 @@
           (reset! current-context ctx)))
       (p/catch (fn [e]
                  ; TODO: Emit event
+                 (log "ERROR Loading init: " e)
                  (reset! state e)))))
 
 (defn- load-string [s]
@@ -85,3 +95,11 @@
     (eval-script context
                  {:first-load? true}
                  s)))
+
+(defn load-script [path]
+  (p/let [buf (fs/readFile path)
+          text (.toString buf)]
+    (load-string text)))
+
+(comment
+  (initialize))

--- a/src/cli/saya/env.cljs
+++ b/src/cli/saya/env.cljs
@@ -3,7 +3,7 @@
    ["node:fs/promises" :as fs]
    [promesa.core :as p]
    [saya.modules.logging.core :refer [log]]
-   [saya.modules.scripting.core :as scripting-core]
+   [saya.modules.scripting.core]
    [saya.util.paths :as paths]
    [sci.core :as sci]))
 
@@ -18,8 +18,8 @@
                              ; a mapping that sends "string" to the connection
                              :readers
                              {'send (fn [text]
-                                      (fn do-send [conn]
-                                        (scripting-core/send conn text)))}})
+                                      `(fn do-send [conn#]
+                                         (~'saya.core/send conn# ~text)))}})
 
 (defn- read-init []
   (-> (p/let [init-path (paths/user-config "init.clj")

--- a/src/cli/saya/env.cljs
+++ b/src/cli/saya/env.cljs
@@ -3,7 +3,7 @@
    ["node:fs/promises" :as fs]
    [promesa.core :as p]
    [saya.modules.logging.core :refer [log]]
-   [saya.modules.scripting.core]
+   [saya.modules.scripting.core :refer [*script-file*]]
    [saya.util.paths :as paths]
    [sci.core :as sci]))
 
@@ -99,7 +99,8 @@
 (defn load-script [path]
   (p/let [buf (fs/readFile path)
           text (.toString buf)]
-    (load-string text)))
+    (binding [*script-file* path]
+      (load-string text))))
 
 (comment
   (initialize))

--- a/src/cli/saya/events.cljs
+++ b/src/cli/saya/events.cljs
@@ -74,7 +74,7 @@
  [unwrap]
  (fn [{:keys [db] :as cofx} {:keys [connr text]}]
    (merge
-    (let [bufnr (get-in db [:connection->bufnr connr])
+    (let [bufnr (get-in db [:connections connr :bufnr])
           winnr (:current-winnr db)]
       ; Scroll to the bottom in the current window (only) IF it is
       ; associated with this connection

--- a/src/cli/saya/events.cljs
+++ b/src/cli/saya/events.cljs
@@ -1,13 +1,13 @@
 (ns saya.events
   (:require
    [re-frame.core :refer [path reg-event-db reg-event-fx trim-v unwrap]]
-   [saya.cli.args :refer [parse-cli-args]]
    [saya.db :as db]
    [saya.modules.command.parse :refer [parse-command]]
    [saya.modules.command.registry]
    [saya.modules.input.keymaps :as keymaps]
    [saya.modules.input.normal :refer [scroll-to-bottom]]
-   [saya.modules.kodachi.fx :as kodachi-fx]))
+   [saya.modules.kodachi.fx :as kodachi-fx]
+   [saya.modules.scripting.fx :as scripting-fx]))
 
 (reg-event-fx
  ::initialize-db
@@ -17,13 +17,19 @@
 (reg-event-fx
  ::initialize-cli
  [trim-v]
- (fn [{:keys [db]} [args]]
+ (fn [{:keys [db]} [cli-args]]
    (try
-     (let [new-db (assoc db :cli/args (parse-cli-args args))]
+     (let [new-db (assoc db :cli/args cli-args)]
        {:db new-db
         :fx [[::kodachi-fx/init new-db]]})
      (catch :default e
        {:db (assoc db :err e)}))))
+
+(reg-event-fx
+ ::load-script
+ [trim-v]
+ (fn [_ [script-file]]
+   {::scripting-fx/load-script script-file}))
 
 (reg-event-db
  ::set-dimens

--- a/src/cli/saya/modules/buffers/events.cljs
+++ b/src/cli/saya/modules/buffers/events.cljs
@@ -67,10 +67,11 @@
       ; Reuse existing buffer
       (-> db
           (update-in current-path assoc :connection-id connection-id)
-          (update :connection->bufnr
+          (update :connections
                   assoc
                   connection-id
-                  (:id current-buffer)))
+                  {:bufnr (:id current-buffer)
+                   :state :connecting}))
 
       ; TODO: Also, tabpage
       (let [[db {buffer :buffer}] (create-blank
@@ -79,10 +80,11 @@
                                     {:uri uri
                                      :connection-id connection-id}})]
         (-> db
-            (update :connection->bufnr
+            (update :connections
                     assoc
                     connection-id
-                    (:id buffer)))))))
+                    {:bufnr (:id buffer)
+                     :state :connecting}))))))
 
 ; NOTE: Adapters like kodachi.events can use the event handler directly, assuming they use [unwrap]
 ; The handler expects the db as its first param; be aware if your event handler is -fx!

--- a/src/cli/saya/modules/command/registry.cljs
+++ b/src/cli/saya/modules/command/registry.cljs
@@ -3,7 +3,8 @@
    [re-frame.registrar :refer [get-handler]]
    [saya.modules.command.registry.buffer]
    [saya.modules.command.registry.connection]
-   [saya.modules.command.registry.core]))
+   [saya.modules.command.registry.core]
+   [saya.modules.command.registry.scripting]))
 
 (defn- extract-aliases [registered-handler]
   ; registered-handler looks like '({:id ...} ...)

--- a/src/cli/saya/modules/command/registry/buffer.cljs
+++ b/src/cli/saya/modules/command/registry/buffer.cljs
@@ -1,7 +1,6 @@
 (ns saya.modules.command.registry.buffer
   (:require
-   [day8.re-frame-10x.inlined-deps.re-frame.v1v3v0.re-frame.core :refer [unwrap]]
-   [re-frame.core :refer [reg-event-fx]]
+   [re-frame.core :refer [reg-event-fx unwrap]]
    [saya.modules.buffers.events :as buffer-events]
    [saya.modules.command.interceptors :refer [aliases]]
    [saya.modules.logging.core :refer [log-fx]]))

--- a/src/cli/saya/modules/command/registry/connection.cljs
+++ b/src/cli/saya/modules/command/registry/connection.cljs
@@ -9,9 +9,14 @@
 (reg-event-fx
  :command/connect
  [(aliases :c :co :con :conn) unwrap]
- (fn [_ {[uri] :params}]
+ (fn [_ {[uri-param] :params :keys [uri]}]
+   ; NOTE: This may be invoked either as:
+   ;   [:command/connect {:uri uri}]
+   ; OR, as from the UI:
+   ;   [:command/connect {:params [uri]}]
    {:dispatch [::kodachi-events/connect
                {:uri (or uri
+                         uri-param
                          (when config/debug?
                            ; TODO: Clean this up
                            "legendsofthejedi.com:5656"))}]}))

--- a/src/cli/saya/modules/command/registry/scripting.cljs
+++ b/src/cli/saya/modules/command/registry/scripting.cljs
@@ -1,0 +1,25 @@
+(ns saya.modules.command.registry.scripting
+  (:require
+   [re-frame.core :refer [reg-event-fx unwrap]]
+   [saya.modules.command.interceptors :refer [aliases]]
+   [saya.modules.scripting.fx :as scripting-fx]))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(reg-event-fx
+ :command/reload
+ [(aliases :r :re :rel) unwrap]
+ (fn [{:keys [db]} _]
+   (let [winnr (:current-window db)
+         bufnr (get-in db [:windows winnr :bufnr])
+         connr (get-in db [:buffers bufnr :connection-id])
+         script-file (get-in db [:connections connr :script-file])]
+      ; TODO: echos
+     (cond
+       (not connr)
+       {:fx [[:log "No connection associated with current buffer."]]}
+
+       (not script-file)
+       {:fx [[:log "No script associated with current connection."]]}
+
+       :else
+       {::scripting-fx/load-script script-file}))))

--- a/src/cli/saya/modules/kodachi/events.cljs
+++ b/src/cli/saya/modules/kodachi/events.cljs
@@ -99,12 +99,19 @@
                [:saya.modules.kodachi.fx/set-window-size!
                 {:connection-id connr
                  :width (:width window)
-                 :height (:height window)}])]}
+                 :height (:height window)}])
+
+             [:saya.modules.scripting.fx/trigger-callback
+              {:connection-id connr
+               :callback-kind :on-connected}]]}
 
        {:type "Disconnected"}
        {:dispatch [::buffer-events/new-line
                    {:id bufnr
-                    :system [:disconnected (get-in db [:buffers bufnr :uri])]}]}
+                    :system [:disconnected (get-in db [:buffers bufnr :uri])]}]
+        :fx [[:saya.modules.scripting.fx/trigger-callback
+              {:connection-id connr
+               :callback-kind :on-disconnected}]]}
 
        ; TODO:
        :else

--- a/src/cli/saya/modules/kodachi/events.cljs
+++ b/src/cli/saya/modules/kodachi/events.cljs
@@ -36,10 +36,9 @@
  ::connecting
  [unwrap]
  (fn [{:keys [db]} {:keys [connection-id uri] :as params}]
-   ; TODO: Stash connection state somewhere?
-   (let [db (buffer-events/create-for-connection db params)
-         bufnr (get-in db [:connection->bufnr connection-id])]
-     {:db db
+   (let [db' (buffer-events/create-for-connection db params)
+         bufnr (get-in db' [:connections connection-id :bufnr])]
+     {:db db'
       :dispatch [::buffer-events/new-line
                  {:id bufnr
                   :system [:connecting uri]}]})))
@@ -49,7 +48,7 @@
  [unwrap]
  (fn [{:keys [db]} {connr :connection_id :as params}]
    (log "<< " params)
-   (when-let [bufnr (get-in db [:connection->bufnr connr])]
+   (when-let [bufnr (get-in db [:connections connr :bufnr])]
      (m/match params
        {:type "ExternalUI"
         :data {:type "Text"
@@ -87,7 +86,8 @@
        ; and we receive it here.
 
        {:type "Connected"}
-       {:fx [[:dispatch
+       {:db (assoc-in db [:connections connr :state] :connected)
+        :fx [[:dispatch
               [::buffer-events/new-line
                {:id bufnr
                 :system [:connected (get-in db [:buffers bufnr :uri])]}]]
@@ -106,7 +106,8 @@
                :callback-kind :on-connected}]]}
 
        {:type "Disconnected"}
-       {:dispatch [::buffer-events/new-line
+       {:db (assoc-in db [:connections connr :state] :disconnected)
+        :dispatch [::buffer-events/new-line
                    {:id bufnr
                     :system [:disconnected (get-in db [:buffers bufnr :uri])]}]
         :fx [[:saya.modules.scripting.fx/trigger-callback

--- a/src/cli/saya/modules/scripting/callbacks.cljs
+++ b/src/cli/saya/modules/scripting/callbacks.cljs
@@ -1,0 +1,13 @@
+(ns saya.modules.scripting.callbacks)
+
+(defonce ^:private registered-callbacks (atom {}))
+
+(defn register-callback [connr callback]
+  (swap! registered-callbacks assoc connr callback))
+
+(defn trigger-callback [connr callback-kind]
+  (when-some [callback (get @registered-callbacks connr)]
+    (callback callback-kind))
+  (when (#{:on-error :on-disconnected} callback-kind)
+    ; Cleanup
+    (swap! registered-callbacks dissoc connr)))

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -54,7 +54,7 @@
 
   ; Else, trigger a connection
   (-> (perform-connect uri)
-      (p/then (partial perform-config config))
+      (p/then #(perform-config % config))
       (p/catch (fn [e]
                  ; TODO: Echo
                  (log "ERROR in config: " e)))))

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -1,80 +1,63 @@
 (ns saya.modules.scripting.core
+  {:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
   (:require
    [archetype.util :refer [>evt]]
    [clojure.core.match :as m]
    [promesa.core :as p]
    [re-frame.core :as rf]
    [saya.modules.kodachi.events :as kodachi]
-   [saya.modules.logging.core :refer [log]]))
+   [saya.modules.logging.core :refer [log]]
+   [saya.modules.scripting.callbacks :refer [register-callback]]))
 
 (defn- perform-connect [uri]
   (let [callback-id [::on-connection uri]
-        my-connr (atom nil)
         stop-listening (fn stop-listening []
                          (rf/remove-post-event-callback callback-id))]
     (p/create
-     (fn [p-resolve p-reject]
+     (fn [p-resolve _]
        (rf/add-post-event-callback
         callback-id
         (fn [[event-name & args] _]
           (m/match [event-name (vec args)]
             [::kodachi/connecting [{:connection-id connection-id
                                     :uri uri}]]
-            (reset! my-connr connection-id)
-
-            [::kodachi/on-message [{:type "Connected"
-                                    :connection_id connr}]]
             (do (stop-listening)
-                (p-resolve connr))
-
-            [::kodachi/on-message [{:type "Disconnected"
-                                    :connection_id connr}]]
-            (when (= connr @my-connr)
-              (stop-listening)
-              (p-reject (ex-info "Disconnected" {:connr connr})))
-
-            [::kodachi/on-error [err]]
-            (do (stop-listening)
-                (p-reject (ex-info "Disconnected" {:err err})))
+                (p-resolve connection-id))
 
             :else nil)))
 
        (>evt [:command/connect {:uri uri}])))))
 
+; "Unpacks" a `conn` into a connr. For now, a no-op
+(def ^:private ->connr identity)
+
+(defn- perform-config [conn {keymaps :keys :as config}]
+  (let [connr (->connr conn)]
+    (register-callback connr (fn [kind]
+                               (when-some [cb (get config kind)]
+                                 (cb conn))))
+
+    ; TODO: 
+    (log "TODO: map keys: " keymaps " for " connr)))
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn on-connection
+(defn setup-connection
   "Ensure that a connection exists in the current window for the given URI,
-   calling the given callback when it's connected (and again if the script is
-   sourced while the connection is active).
+   configuring the associated buffer with the params provided.
    If called when a connection exists for another URI, this function is a
-   nop (and the callback will not be called).
+   nop (and any callbacks will not be called).
    "
-  [uri f]
+  [uri & config]
   ; TODO: First, check if we're already actively connected. If so,
-  ; call f directly
+  ; perform config directly
 
   ; Else, trigger a connection
   (-> (perform-connect uri)
+      (p/then (partial perform-config config))
       (p/catch (fn [e]
                  ; TODO: Echo
-                 (log "ERROR Connecting to " uri ": " e)))
-      (p/then f)
-      (p/catch (fn [e]
-                 ; TODO: Echo
-                 (log "ERROR in connection handler: " e)))))
+                 (log "ERROR in config: " e)))))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn ^:sci/macro with-connection [_&form _&env uri & body]
-  `(saya.core/on-connection
-    ~uri
-    (fn [connection#]
-      (p/do
-        ~@body))))
-
-(defn keymap-set [conn mode lhs rhs]
-  ; TODO:
-  )
-
 (defn send [conn s]
-  ; TODO:
-  )
+  (>evt [:connection/send {:connr (->connr conn) :text s}]))

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -1,0 +1,70 @@
+(ns saya.modules.scripting.core
+  (:require
+   [archetype.util :refer [>evt]]
+   [clojure.core.match :as m]
+   [promesa.core :as p]
+   [re-frame.core :as rf]
+   [saya.modules.kodachi.events :as kodachi]
+   [saya.modules.logging.core :refer [log]]))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn on-connection
+  "Ensure that a connection exists in the current window for the given URI,
+   calling the given callback when it's connected (and again if the script is
+   sourced while the connection is active).
+   If called when a connection exists for another URI, this function is a
+   nop (and the callback will not be called).
+   "
+  [uri f]
+  ; TODO: First, check if we're already actively connected. If so,
+  ; call f directly
+
+  ; Else, trigger a connection
+  (let [callback-id [::on-connection uri]
+        my-connr (atom nil)
+        stop-listening (fn stop-listening []
+                         (rf/remove-post-event-callback callback-id))
+        handle-error (fn handle-error [e]
+                       ; TODO: echo
+                       (log "ERROR: " e))]
+    (rf/add-post-event-callback
+     (fn [[event-name & args] _]
+       (m/match [event-name (vec args)]
+         [::kodachi/connecting [{:connection-id connection-id
+                                 :uri uri}]]
+         (reset! my-connr connection-id)
+
+         [::kodachi/on-message [{:type "Connected"
+                                 :connection_id connr}]]
+         (-> (p/do
+               (f connr))
+             (p/catch handle-error)
+             (p/finally stop-listening))
+
+         [::kodachi/on-message [{:type "Disconnected"
+                                 :connection_id connr}]]
+         (when (= connr @my-connr)
+           (stop-listening))
+
+         [::kodachi/on-error _]
+         (stop-listening)
+
+         :else nil)))
+
+    (>evt [:command/connect {:uri uri}])))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn ^:sci/macro with-connection [_&form _&env uri & body]
+  `(saya.core/on-connection
+    ~uri
+    (fn [connection#]
+      (p/do
+        ~@body))))
+
+(defn keymap-set [conn mode lhs rhs]
+  ; TODO:
+  )
+
+(defn send [conn s]
+  ; TODO:
+  )

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -3,6 +3,7 @@
   (:require
    [archetype.util :refer [>evt]]
    [clojure.core.match :as m]
+   [clojure.string :as str]
    [promesa.core :as p]
    [re-frame.core :as rf]
    [saya.modules.kodachi.events :as kodachi]
@@ -60,4 +61,7 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn send [conn s]
-  (>evt [:connection/send {:connr (->connr conn) :text s}]))
+  (let [text (cond
+               (string? s) s
+               (coll? s) (str/join "\r\n" s))]
+    (>evt [:connection/send {:connr (->connr conn) :text text}])))

--- a/src/cli/saya/modules/scripting/events.cljs
+++ b/src/cli/saya/modules/scripting/events.cljs
@@ -1,0 +1,9 @@
+(ns saya.modules.scripting.events
+  (:require
+   [re-frame.core :refer [reg-event-db unwrap]]))
+
+(reg-event-db
+ ::assign-script-to-connection
+ [unwrap]
+ (fn [db {:keys [connection-id script-file]}]
+   (assoc-in db [:connection connection-id :script] script-file)))

--- a/src/cli/saya/modules/scripting/fx.cljs
+++ b/src/cli/saya/modules/scripting/fx.cljs
@@ -1,5 +1,6 @@
 (ns saya.modules.scripting.fx
   (:require
+   [promesa.core :as p]
    [re-frame.core :refer [reg-fx]]
    [saya.env :as env]
    [saya.modules.logging.core :refer [log]]
@@ -16,4 +17,6 @@
  (fn [script-path]
    (let [expanded-path (paths/resolve-user script-path)]
      (log "[script:load] " script-path)
-     (env/load-script expanded-path))))
+     (-> (env/load-script expanded-path)
+         (p/catch (fn [e]
+                    (log "[script:load] ERROR: " e)))))))

--- a/src/cli/saya/modules/scripting/fx.cljs
+++ b/src/cli/saya/modules/scripting/fx.cljs
@@ -1,0 +1,19 @@
+(ns saya.modules.scripting.fx
+  (:require
+   [re-frame.core :refer [reg-fx]]
+   [saya.env :as env]
+   [saya.modules.logging.core :refer [log]]
+   [saya.modules.scripting.callbacks :refer [trigger-callback]]
+   [saya.util.paths :as paths]))
+
+(reg-fx
+ ::trigger-callback
+ (fn [{:keys [connection-id callback-kind]}]
+   (trigger-callback connection-id callback-kind)))
+
+(reg-fx
+ ::load-script
+ (fn [script-path]
+   (let [expanded-path (paths/resolve-user script-path)]
+     (log "[script:load] " script-path)
+     (env/load-script expanded-path))))

--- a/src/cli/saya/util/paths.cljs
+++ b/src/cli/saya/util/paths.cljs
@@ -2,7 +2,8 @@
   (:require [applied-science.js-interop :as j]
             ["env-paths" :as env-paths]
             ["node:os" :as os]
-            ["node:path" :as path]))
+            ["node:path" :as path]
+            ["untildify" :default untildify]))
 
 (def ^:private app-name "saya")
 
@@ -23,3 +24,10 @@
   ([] (platform :data))
   ([sub-path]
    (path/join (internal-data) sub-path)))
+
+(defn resolve-user
+  "Given a user-provided path, resolve the absolute path to it,
+   handling things like ~ for HOME"
+  [user-path]
+  (-> (untildify user-path)
+      (path/resolve)))


### PR DESCRIPTION
Currently we support connecting via `saya.core/setup-connection` and `:on-connected` callbacks, including a custom tagged literal `#send` that will return a function that sends the literal text (or lines of text, by putting them in a vector) when called.

Setting aliases, triggers, etc. to come later. User keymaps, etc. also coming soon

Also, the `:load`/`:source` command (indecisive here) will probably come later when we add support for parsing command args. For now, `:reload` should work when you pass a script path as a CLI param.

TODO:

- [x] Handle the "already loaded" case (fill in the TODO)
- [x] Add a "reload" command
