### PR TITLE
Fix various cmdline mode issues

### DIFF
--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -2,7 +2,6 @@
   (:require
    [clojure.core.match :refer [match]]
    [re-frame.core :refer [reg-event-fx trim-v]]
-   [saya.modules.buffers.line :refer [->ansi]]
    [saya.modules.buffers.util :as buffers]
    [saya.modules.command.interceptors :refer [with-buffer-context]]
    [saya.modules.input.fx :as fx]
@@ -14,8 +13,9 @@
 
 (defn- get-current-cmdline [db bufnr]
   (let [{:keys [lines cursor]} (get-in db [:buffers bufnr])
-        current-line (nth lines (:row cursor))]
-    (->ansi current-line)))
+        current-line (when (seq lines)
+                       (nth lines (:row cursor)))]
+    (str current-line)))
 
 (reg-event-fx
  ::submit-cmdline

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -9,12 +9,16 @@
   (str line))
 
 (defn update-buffer-line-string [buffer linenr f]
-  (-> buffer
-      (update-in [:lines linenr]
-                 (comp
-                  buffer-line
-                  f
-                  (fnil str "")))))
+  (cond-> buffer
+    (not (:lines buffer))
+    (assoc :lines [])
+
+    :always
+    (update-in [:lines linenr]
+               (comp
+                buffer-line
+                f
+                (fnil str "")))))
 
 (defn- update-cursor-line-string [{:keys [buffer] :as context} f]
   (let [{linenr :row} (:cursor buffer)]

--- a/src/cli/saya/modules/window/events.cljs
+++ b/src/cli/saya/modules/window/events.cljs
@@ -32,4 +32,4 @@
    (assoc-in db [:buffers [:conn/input connr] :lines]
              (->> text
                   (str/split-lines)
-                  (map buffer-line)))))
+                  (mapv buffer-line)))))

--- a/src/cli/saya/modules/window/subs.cljs
+++ b/src/cli/saya/modules/window/subs.cljs
@@ -60,7 +60,8 @@
     (subscribe [::buffer-subs/by-id bufnr])
     (subscribe [::buffer-subs/lines-by-id bufnr])])
  (fn [[window buffer buffer-lines]]
-   (or (seq (visible-lines window buffer-lines))
+   (or (seq (when buffer-lines
+              (visible-lines window buffer-lines)))
 
        ; NOTE: Non-connection buffers need some blank "starter" line
        ; for editing purposes

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -40,8 +40,14 @@
     :completion (->ConnectionCompletionSource connr)
     :on-persist-value #(>evt [::window-events/set-input-text {:connr connr
                                                               :text %}])
-    :on-submit #(>evt [:connection/send {:connr connr
-                                         :text %}])}])
+    :on-submit (fn [text]
+                 ; NOTE: Ensure input is cleared; on-persist-value *may not*
+                 ; be called from the cmdline window. This is kinda hacks,
+                 ; but fixing properly in input-window feels... annoying
+                 (>evt [::window-events/set-input-text {:connr connr
+                                                        :text ""}])
+                 (>evt [:connection/send {:connr connr
+                                          :text text}]))}])
 
 (defn- buffer-line [{:keys [line col]} {:keys [cursor-col input-connr]}]
   (let [cursor-type (case (<sub [:mode])


### PR DESCRIPTION
Fixes #13

- **Fix: error submitting command from empty buffer**
- **Gracefully render empty buffers without lines**
- **Ensure :lines is always created as a vector**
- **Gracefully "fill in" buffers missing :lines on insert**
