### PR TITLE
Add basic support for single-line prompts

### DIFF
--- a/src/cli/saya/modules/command/registry/connection.cljs
+++ b/src/cli/saya/modules/command/registry/connection.cljs
@@ -9,7 +9,7 @@
 (reg-event-fx
  :command/connect
  [(aliases :c :co :con :conn) unwrap]
- (fn [_ {[uri-param] :params :keys [uri]}]
+ (fn [_ {[uri-param] :params :keys [uri auto-prompts]}]
    ; NOTE: This may be invoked either as:
    ;   [:command/connect {:uri uri}]
    ; OR, as from the UI:
@@ -19,7 +19,8 @@
                          uri-param
                          (when config/debug?
                            ; TODO: Clean this up
-                           "legendsofthejedi.com:5656"))}]}))
+                           "legendsofthejedi.com:5656"))
+                :auto_prompts auto-prompts}]}))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (reg-event-fx

--- a/src/cli/saya/modules/kodachi/events.cljs
+++ b/src/cli/saya/modules/kodachi/events.cljs
@@ -115,6 +115,11 @@
               {:connection-id connr
                :callback-kind :on-disconnected}]]}
 
+       {:type "PromptUpdated"}
+       {:db (assoc-in db [:connections connr :prompts
+                          (:group_id params) (:index params)]
+                      (get-in params [:content :ansi]))}
+
        ; TODO:
        :else
        nil))))
@@ -122,8 +127,8 @@
 (reg-event-fx
  ::connect
  [unwrap]
- (fn [_ {:keys [uri]}]
-   {:saya.modules.kodachi.fx/connect! {:uri uri}}))
+ (fn [_ payload]
+   {:saya.modules.kodachi.fx/connect! payload}))
 
 (reg-event-fx
  ::disconnect

--- a/src/cli/saya/modules/kodachi/fx.cljs
+++ b/src/cli/saya/modules/kodachi/fx.cljs
@@ -18,9 +18,11 @@
 
 (reg-fx
  ::connect!
- (fn [{:keys [uri]}]
-   (p/let [{:keys [connection_id]} (api/request! {:type :Connect
-                                                  :uri uri})]
+ (fn [{:keys [uri] :as payload}]
+   (p/let [{:keys [connection_id]} (api/request!
+                                    (merge
+                                     payload
+                                     {:type :Connect}))]
      (log "Opened connection" connection_id "to" uri)
      (>evt [::events/connecting {:uri uri
                                  :connection-id connection_id}])

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -16,7 +16,7 @@
 
 ; ======= setup-connection =================================
 
-(defn- perform-connect [uri]
+(defn- perform-connect [uri {:keys [auto-prompt?]}]
   (let [callback-id [::on-connection uri]
         stop-listening (fn stop-listening []
                          (rf/remove-post-event-callback callback-id))]
@@ -33,7 +33,8 @@
 
             :else nil)))
 
-       (>evt [:command/connect {:uri uri}])))))
+       (>evt [:command/connect {:uri uri
+                                :auto-prompts auto-prompt?}])))))
 
 ; "Unpacks" a `conn` into a connr. For now, a no-op
 (def ^:private ->connr identity)
@@ -78,7 +79,7 @@
 
       ; Else, trigger a connection
       :else
-      (-> (perform-connect uri)
+      (-> (perform-connect uri config)
           (p/then #(binding [*script-file* script-file]
                      (perform-config % config)))
           (p/catch (fn [e]

--- a/src/cli/saya/modules/window/subs.cljs
+++ b/src/cli/saya/modules/window/subs.cljs
@@ -106,3 +106,20 @@
  (fn [buffer]
    (->> (:lines buffer)
         (str/join "\n"))))
+(reg-sub
+ ::connections
+ :-> :connections)
+
+(reg-sub
+ ::connection-by-id
+ :<- [::connections]
+ :=> get)
+
+(reg-sub
+ ::single-prompt
+ (fn [[_ connr]]
+   (subscribe [::connection-by-id connr]))
+ (fn [{:keys [prompts]} _]
+   (when (and (= 1 (count prompts))
+              (= 1 (count (get prompts 0))))
+     (get-in prompts [0 0]))))

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -162,17 +162,21 @@
 
                  (when (and input-line? inputting?)
                    [input-window input-connr])]))]
-           (cond
-             (and scrolled? input-focused? input-connr)
-             [input-window (<sub [::buffer-subs/->connr bufnr])]
+           [:> k/Box {:flex-direction :row
+                      :flex-wrap :wrap}
+            (when scrolled?
+              [conn-single-prompt input-connr])
+            (cond
+              (and scrolled? input-focused? input-connr)
+              [input-window (<sub [::buffer-subs/->connr bufnr])]
 
-             (and scrolled? input-connr)
-             [input-placeholder input-connr]
+              (and scrolled? input-connr)
+              [input-placeholder input-connr]
 
-             scrolled?
-             [placeholders/line]
+              scrolled?
+              [placeholders/line]
 
-             ; NOTE: We *may* actually want to render something here to avoid the
-             ; window size changing when we scroll... For now, though...
-             ; it looks nicer without anything!
-             :else nil)])))))
+              ; NOTE: We *may* actually want to render something here to avoid the
+              ; window size changing when we scroll... For now, though...
+              ; it looks nicer without anything!
+              :else nil)]])))))

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -96,6 +96,10 @@
                 :wrap :truncate-end}
      text]))
 
+(defn- conn-single-prompt [input-connr]
+  (when-some [single-prompt (<sub [::subs/single-prompt input-connr])]
+    [:> k/Text single-prompt]))
+
 (defn window-view [id]
   (let [ref (React/useRef)]
     (React/useLayoutEffect
@@ -149,6 +153,12 @@
                   :suffix-text (when (and input-line?
                                           (not inputting?))
                                  [input-placeholder input-connr])}
+
+                 ; NOTE: This *should* be relatively safe due to the way 
+                 ; Kodachi clears the "partial" line to handle prompts
+                 (when (and input-line? (empty? line))
+                   [conn-single-prompt input-connr])
+
                  (when (and input-line? inputting?)
                    [input-window input-connr])]))]
            (cond

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -150,14 +150,15 @@
                   ; chars get truncated from the buffer-line part... It's
                   ; definitely something to do with our cursor hack but I'm not
                   ; certain *what*, exactly.
-                  :suffix-text (when (and input-line?
-                                          (not inputting?))
-                                 [input-placeholder input-connr])}
-
-                 ; NOTE: This *should* be relatively safe due to the way 
-                 ; Kodachi clears the "partial" line to handle prompts
-                 (when (and input-line? (empty? line))
-                   [conn-single-prompt input-connr])
+                  :suffix-text [:<>
+                                ; NOTE: This *should* be relatively safe
+                                ; due to the way Kodachi clears the
+                                ; "partial" line to handle prompts
+                                (when (and input-line? (empty? line))
+                                  [conn-single-prompt input-connr])
+                                (when (and input-line?
+                                           (not inputting?))
+                                  [input-placeholder input-connr])]}
 
                  (when (and input-line? inputting?)
                    [input-window input-connr])]))]


### PR DESCRIPTION
Closes #20 (for now)

Will be easier to support multi prompts when I find a MUD where I use them again, but in the meantime this should support dhleong/kodachi#31

Includes a new `:auto-prompt? true` config key on `setup-connection` to enable Kodachi's EOR-based automatic prompt extraction.
