### PR TITLE
Throttle kodachi messages to apply in batch

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ink": "^6.5.1",
     "ink-spinner": "^5.0.0",
     "ink-use-stdout-dimensions": "^1.0.5",
+    "lodash": "^4.17.21",
     "react": "^19",
     "react-dom": "^19",
     "split2": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       ink-use-stdout-dimensions:
         specifier: ^1.0.5
         version: 1.0.5(ink@6.5.1(patch_hash=4zs6u7zfx2hrh3klcma7bkxgsq)(react@19.2.0))(react@19.2.0)
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       react:
         specifier: ^19
         version: 19.2.0
@@ -442,6 +445,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1169,6 +1175,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  lodash@4.17.21: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/cli/saya/modules/kodachi/events.cljs
+++ b/src/cli/saya/modules/kodachi/events.cljs
@@ -132,12 +132,7 @@
    (let [bufnr (get-in db [:connections connr :bufnr])]
      (cond
        (some? bufnr)
-       (process-message db connr bufnr params)
-
-       (and (seq js/process.env.REPLAY_DUMP)
-            (= "Connecting" (:type params)))
-       {:dispatch [::connecting {:uri "replay"
-                                 :connection-id connr}]}))))
+       (process-message db connr bufnr params)))))
 
 (reg-event-fx
  ::connect


### PR DESCRIPTION
This somewhat side-steps the perf issue with lines heavy in ansi colors,
but can still be helpful when receiving a large volume of lines (such as
when viewing a help document). One large kodachi dump I have went from
~4s to replay down to ~3s, while a smaller dump that took ~1.8s
dropped down to ~500ms.

The latter diff is somewhat artificial, since what it's really saving is
having to render a screenful of lines that are very heavy with ansi---if
you jump upward a page, all of those are forced to render at once,
resulting in a multi-second hang. Not ideal! But, I do think this is
still an improvement.

At higher throttle durations we can get even more gains, at the cost of
lower rendering. This seems like a fine balance for now; cranking it up
*could* help us focus our profiling efforts to optimize our handling of
heavy ansi lines...
