### PR TITLE
Improve search performance

### DIFF
--- a/src/cli/saya/modules/buffers/events.cljs
+++ b/src/cli/saya/modules/buffers/events.cljs
@@ -98,8 +98,8 @@
              (fnil conj (buffer-line))
              (if system
                {:system system}
-               (cond-> {:ansi ansi
-                        :plain plain}
+               (cond-> {:ansi ansi}
+                 plain (assoc :plain plain)
                  full-line? (assoc :full-line? true)))))
 
 (reg-event-db

--- a/src/cli/saya/modules/buffers/events.cljs
+++ b/src/cli/saya/modules/buffers/events.cljs
@@ -93,12 +93,13 @@
 ;  [unwrap]
 ;  create-for-connection)
 
-(defn append-text [buffer {:keys [ansi full-line? system]}]
+(defn append-text [buffer {:keys [ansi plain full-line? system]}]
   (update-in buffer [:lines (dec (count (:lines buffer)))]
              (fnil conj (buffer-line))
              (if system
                {:system system}
-               (cond-> {:ansi ansi}
+               (cond-> {:ansi ansi
+                        :plain plain}
                  full-line? (assoc :full-line? true)))))
 
 (reg-event-db

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -141,9 +141,9 @@
 
     (and (map? o)
          (:ansi o))
-    (-> o
-        (update :ansi strip-unprintable)
-        (update :plain strip-unprintable))
+    (cond-> (update o :ansi strip-unprintable)
+      (:plain o)
+      (update :plain strip-unprintable))
 
     :else o))
 

--- a/src/cli/saya/modules/kodachi/events.cljs
+++ b/src/cli/saya/modules/kodachi/events.cljs
@@ -48,12 +48,15 @@
   (m/match params
     {:type "ExternalUI"
      :data {:type "Text"
-            :ansi ansi}}
+            :ansi ansi
+            :plain plain}}
     {:dispatch [::buffer-events/append-text
-                (let [ansi' (str/trim-newline ansi)]
+                (let [ansi' (str/trim-newline ansi)
+                      plain' (str/trim-newline plain)]
                   {:id bufnr
-                   :full-line? (not= ansi' ansi)
-                   :ansi ansi'})]}
+                   :full-line? (not= plain' plain)
+                   :ansi ansi'
+                   :plain plain'})]}
 
     {:type "ExternalUI"
      :data {:type "LocalSend"

--- a/src/cli/saya/modules/search/core.cljs
+++ b/src/cli/saya/modules/search/core.cljs
@@ -27,7 +27,7 @@
           :else
           (seq results))))))
 
-(defn in-string [s direction query]
+(defn in-plain-string [s direction query]
   (find-all
    s
    (case direction
@@ -77,7 +77,7 @@
                      ; TODO: Can we avoid the garbage of stripping ansi?
                      ; Is it worth it?
                      (-> (->plain line)
-                         (in-string direction query)
+                         (in-plain-string direction query)
                          (->> (map (fn [match]
                                      (assoc-in match [:at :row] linenr)))))))
            (drop-while #(or (= (:at %)

--- a/src/test/saya/modules/search/core_test.cljs
+++ b/src/test/saya/modules/search/core_test.cljs
@@ -2,26 +2,26 @@
   (:require
    [cljs.test :refer-macros [deftest is testing]]
    [saya.modules.buffers.line :refer [buffer-line]]
-   [saya.modules.search.core :refer [in-buffer in-string]]))
+   [saya.modules.search.core :refer [in-buffer in-plain-string]]))
 
 (deftest search-in-string-test
   (testing "Handle negative case"
     (is (nil?
-         (in-string "bacon ipsum al pastor"
-                    :newer
-                    "birria"))))
+         (in-plain-string "bacon ipsum al pastor"
+                          :newer
+                          "birria"))))
 
   (testing "Simple search"
     (is (= [{:at {:col 0}
              :length 9}]
-           (in-string "al pastor"
-                      :newer
-                      "al pastor")))
+           (in-plain-string "al pastor"
+                            :newer
+                            "al pastor")))
     (is (= [{:at {:col 12}
              :length 9}]
-           (in-string "bacon ipsum al pastor"
-                      :newer
-                      "al pastor"))))
+           (in-plain-string "bacon ipsum al pastor"
+                            :newer
+                            "al pastor"))))
 
   (testing "Multiple Results in a line"
     (is (= [{:at {:col 0}
@@ -30,32 +30,18 @@
              :length 2}
             {:at {:col 4}
              :length 2}]
-           (in-string "alalal"
-                      :newer
-                      "al")))
+           (in-plain-string "alalal"
+                            :newer
+                            "al")))
     (is (= [{:at {:col 4}
              :length 2}
             {:at {:col 2}
              :length 2}
             {:at {:col 0}
              :length 2}]
-           (in-string "alalal"
-                      :older
-                      "al"))))
-
-  (testing "Ansi search"
-    (is (= [{:at {:col 0}
-             :length 9}]
-           (in-string "\u001b[32mal pastor"
-                      :newer
-                      "al pastor"))))
-
-  (testing "Mixed-in Ansi search"
-    (is (= [{:at {:col 0}
-             :length 9}]
-           (in-string "\u001b[32mal \u001b[33mpastor"
-                      :newer
-                      "al pastor")))))
+           (in-plain-string "alalal"
+                            :older
+                            "al")))))
 
 (deftest search-in-buffer-test
   (testing "Order reverse search results correctly"
@@ -141,4 +127,22 @@
                       :col 8}}
             :newer
             "burrito"))
-        "starting on the last of multiple matches in a line")))
+        "starting on the last of multiple matches in a line"))
+
+  (testing "Ansi search"
+    (is (= [{:at {:col 0 :row 0}
+             :length 9}]
+           (in-buffer
+            {:lines [(buffer-line "\u001b[32mal pastor")]
+             :cursor {:row 1 :col 0}}
+            :older
+            "al pastor"))))
+
+  (testing "Mixed-in Ansi search"
+    (is (= [{:at {:col 0 :row 0}
+             :length 9}]
+           (in-buffer
+            {:lines [(buffer-line "\u001b[32mal \u001b[33mpastor")]
+             :cursor {:row 1 :col 0}}
+            :older
+            "al pastor")))))

--- a/src/test/saya/modules/window/input_window_test.cljs
+++ b/src/test/saya/modules/window/input_window_test.cljs
@@ -1,5 +1,6 @@
 (ns saya.modules.window.input-window-test
   (:require
+   ["strip-ansi" :default strip-ansi]
    [archetype.util :refer [>evt]]
    [cljs.test :refer-macros [deftest is testing]]
    [day8.re-frame.test :as rft]
@@ -15,7 +16,8 @@
   (>evt [::kodachi-events/on-message {:connection_id 0
                                       :type "ExternalUI"
                                       :data {:type "Text"
-                                             :ansi text}}]))
+                                             :ansi text
+                                             :plain (strip-ansi text)}}]))
 (defn receive-newline []
   (>evt [::kodachi-events/on-message {:connection_id 0
                                       :type "ExternalUI"


### PR DESCRIPTION
By using Kodachi's new feature to pre-process ansi, we can significantly speed up search performance. Before, it was basically unusable after a thousand lines or so due to having to constantly strip ansi. Now, it's even pretty usable up to 10k lines, and while it's still fast enough, we run into it being slow enough that the input ordering gets garbled or something, which is annoying but something we should look into separately.

- **Restore ->plain and use it for buffer search; integrate Kodachi's :plain**
- **Fix: trying to operate on nil :plain**
- **Migrate ansi search tests to buffer tests; encode search/in-plain-string**
- **Update input-window-test to eagerly strip-ansi**
