### PR TITLE
Significantly optimize line wrapping and ansi handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ws": "^8.18.0"
   },
   "dependencies": {
+    "@alcalzone/ansi-tokenize": "^0.3.0",
     "ansi-escapes": "^7.3.0",
     "ansi-parser": "^3.2.11",
     "ansi-regex": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@alcalzone/ansi-tokenize": "^0.3.0",
     "ansi-escapes": "^7.3.0",
-    "ansi-parser": "^3.2.11",
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
     "highlight.js": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@alcalzone/ansi-tokenize": "^0.3.0",
     "ansi-escapes": "^7.3.0",
     "ansi-parser": "^3.2.11",
-    "ansi-regex": "^6.1.0",
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
     "highlight.js": "11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ importers:
       ansi-parser:
         specifier: ^3.2.11
         version: 3.2.11
-      ansi-regex:
-        specifier: ^6.1.0
-        version: 6.1.0
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     dependencies:
+      '@alcalzone/ansi-tokenize':
+        specifier: ^0.3.0
+        version: 0.3.0
       ansi-escapes:
         specifier: ^7.3.0
         version: 7.3.0
@@ -299,10 +302,6 @@ packages:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
-
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -410,10 +409,6 @@ packages:
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  is-fullwidth-code-point@5.0.0:
-    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
-    engines: {node: '>=18'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -763,7 +758,7 @@ snapshots:
   '@alcalzone/ansi-tokenize@0.3.0':
     dependencies:
       ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.0.0
+      is-fullwidth-code-point: 5.1.0
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -1034,8 +1029,6 @@ snapshots:
 
   get-east-asian-width@1.2.0: {}
 
-  get-east-asian-width@1.4.0: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.2.4:
@@ -1169,13 +1162,9 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-fullwidth-code-point@5.0.0:
-    dependencies:
-      get-east-asian-width: 1.4.0
-
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.6.0
 
   is-in-ci@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       ansi-escapes:
         specifier: ^7.3.0
         version: 7.3.0
-      ansi-parser:
-        specifier: ^3.2.11
-        version: 3.2.11
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
@@ -75,9 +72,6 @@ packages:
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
-
-  ansi-parser@3.2.11:
-    resolution: {integrity: sha512-HeEwCVf/pI9qQUVaTkoDBl9U/QU4RvWJ+Trg1jNSNvDzFsBAId6fHv6VLiC7HzwrOiL8uOEkO5T1eTgpnTFQfQ==}
 
   ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
@@ -760,8 +754,6 @@ snapshots:
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
-
-  ansi-parser@3.2.11: {}
 
   ansi-regex@6.1.0: {}
 

--- a/src/cli/saya/modules/ansi/split.cljs
+++ b/src/cli/saya/modules/ansi/split.cljs
@@ -1,49 +1,17 @@
 (ns saya.modules.ansi.split
   (:require
    ["@alcalzone/ansi-tokenize" :as ansi]
-   ["ansi-regex" :default ansi-regex]
    [applied-science.js-interop :as j]))
 
-(defn chars-with-ansi-old [s]
-  {:pre [(string? s)]}
-  (let [regex (ansi-regex)]
-    (loop [start 0
-           pending-ansi nil
-           result []]
-      (let [m (.exec regex s)
-            ansi (get m 0)
-            end (if ansi
-                  (.-lastIndex regex)
-                  (count s))
-            without-ansi (subs s start (- end
-                                          (count ansi)))
-            new-result (if (and (seq without-ansi) pending-ansi)
-                         (-> result
-                             (conj (str pending-ansi
-                                        (first without-ansi)))
-                             (into (next without-ansi)))
+(defn ->ansi-tokens [^String s]
+  (ansi/tokenize s))
 
-                         (into result without-ansi))]
-        (cond
-          ansi
-          (recur end
-                 ansi
-                 new-result)
-
-          ; If there's a pending ansi at the end, tack it onto
-          ; the last visible character
-          (and pending-ansi (seq new-result))
-          (update new-result (dec (count new-result)) str pending-ansi)
-
-          pending-ansi
-          [pending-ansi]
-
-          :else
-          new-result)))))
-
-(defn chars-with-ansi [^String s]
-  (->> (ansi/tokenize s)
-       (ansi/styledCharsFromTokens)
-       (map (j/fn [^:js {:keys [value styles]}]
-              (str (ansi/ansiCodesToString styles)
-                   value)))))
+(defn tokens->chars-with-ansi [toks]
+  (concat
+   (->> toks
+        (take-while (complement vector?))
+        (ansi/styledCharsFromTokens)
+        (map (j/fn [^:js {:keys [value styles]}]
+               (str (ansi/ansiCodesToString styles)
+                    value))))
+   (drop-while (complement vector?) toks)))

--- a/src/cli/saya/modules/ansi/split.cljs
+++ b/src/cli/saya/modules/ansi/split.cljs
@@ -1,8 +1,10 @@
 (ns saya.modules.ansi.split
   (:require
-   ["ansi-regex" :default ansi-regex]))
+   ["@alcalzone/ansi-tokenize" :as ansi]
+   ["ansi-regex" :default ansi-regex]
+   [applied-science.js-interop :as j]))
 
-(defn chars-with-ansi [s]
+(defn chars-with-ansi-old [s]
   {:pre [(string? s)]}
   (let [regex (ansi-regex)]
     (loop [start 0
@@ -38,3 +40,10 @@
 
           :else
           new-result)))))
+
+(defn chars-with-ansi [^String s]
+  (->> (ansi/tokenize s)
+       (ansi/styledCharsFromTokens)
+       (map (j/fn [^:js {:keys [value styles]}]
+              (str (ansi/ansiCodesToString styles)
+                   value)))))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -10,12 +10,17 @@
                                          (count suffix)))))
 
 (defn- finalize-line [line]
-  (tufte/p
-   ::finalize-line
-   (-> (.stringify AnsiParser (to-array line))
-        ; This trailing "reset styles" is "nice" but unnecessary.
-        ; ink should handle it for us, so keeping it is just noise
-       (trim-suffix "\u001B[0m"))))
+  (if (string? (first line))
+    (tufte/p
+     ::finalize-line-string
+     line)
+
+    (tufte/p
+     ::finalize-line-parser
+     (-> (.stringify AnsiParser (to-array line))
+          ; This trailing "reset styles" is "nice" but unnecessary.
+          ; ink should handle it for us, so keeping it is just noise
+         (trim-suffix "\u001B[0m")))))
 
 (defn- is-space? [part]
   (= " " (.-content part)))
@@ -35,12 +40,12 @@
           (remove #(is-space? (first %)))
           (map count))))))
 
-(defn- do-wrap-ansi [s width]
+(defn wrap-ansi-chars [ansi-chars width]
   {:pre [(number? width)]}
   (loop [lines []
          current-line []
          current-line-width 0
-         ansi-chars (->ansi-chars s)
+         ansi-chars ansi-chars
          word-lengths (->word-lengths ansi-chars)]
 
     (if (empty? ansi-chars)
@@ -76,4 +81,4 @@
 (defn wrap-ansi [s width]
   (tufte/p
    ::wrap-ansi
-   (do-wrap-ansi s width)))
+   (wrap-ansi-chars (->ansi-chars s) width)))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -3,11 +3,6 @@
    [clojure.string :as str]
    [taoensso.tufte :as tufte]))
 
-(defn trim-suffix [s suffix]
-  (cond-> s
-    (str/ends-with? s suffix) (subs 0 (- (count s)
-                                         (count suffix)))))
-
 (defn- is-space? [part]
   (str/ends-with? part " "))
 

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -1,30 +1,15 @@
 (ns saya.modules.ansi.wrap
   (:require
-   ["ansi-parser" :default AnsiParser]
    [clojure.string :as str]
    [taoensso.tufte :as tufte]))
 
-(defn- trim-suffix [s suffix]
+(defn trim-suffix [s suffix]
   (cond-> s
     (str/ends-with? s suffix) (subs 0 (- (count s)
                                          (count suffix)))))
 
-(defn- finalize-line [line]
-  (tufte/p
-   ::finalize-line-parser
-   (-> (.stringify AnsiParser (to-array line))
-          ; This trailing "reset styles" is "nice" but unnecessary.
-          ; ink should handle it for us, so keeping it is just noise
-       (trim-suffix "\u001B[0m"))))
-
 (defn- is-space? [part]
-  (= " " (or (.-value part)
-             (.-content part))))
-
-(defn- ->ansi-chars [^String s]
-  (tufte/p
-   ::ansi-chars
-   (seq (.parse AnsiParser s))))
+  (str/ends-with? part " "))
 
 (defn- ->word-lengths [ansi-chars]
   (tufte/p
@@ -32,12 +17,11 @@
    (->> ansi-chars
         (sequence
          (comp
-          (remove #(= "ansi" (.-type %)))
           (partition-by is-space?)
           (remove #(is-space? (first %)))
           (map count))))))
 
-(defn- wrap-ansi-chars-internal [finalize ansi-chars width]
+(defn wrap-ansi-chars [ansi-chars width]
   {:pre [(number? width)]}
   (loop [lines []
          current-line []
@@ -47,7 +31,7 @@
 
     (if (empty? ansi-chars)
       ; Done!
-      (conj lines (finalize current-line))
+      (conj lines current-line)
 
       (let [word-len (first word-lengths)
             want-to-take (inc word-len)
@@ -60,25 +44,15 @@
         (if (> (+ current-line-width word-len 1)
                width)
           ; Wrap
-          (recur (conj lines (finalize current-line))
+          (recur (conj lines current-line)
                  (into [] (take to-take ansi-chars))
-                 ; (to-array (take to-take ansi-chars))
                  to-take ; new line initial length
                  (drop to-take ansi-chars)
                  next-word-lengths)
 
           ; Continue on line
           (recur lines
-                 ; (into current-line (take to-take ansi-chars))
                  (into current-line (take to-take ansi-chars))
                  (+ current-line-width to-take)
                  (drop to-take ansi-chars)
                  next-word-lengths))))))
-
-(defn wrap-ansi-chars [ansi-chars width]
-  (wrap-ansi-chars-internal identity ansi-chars width))
-
-(defn wrap-ansi [s width]
-  (tufte/p
-   ::wrap-ansi
-   (wrap-ansi-chars-internal finalize-line (->ansi-chars s) width)))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -10,17 +10,12 @@
                                          (count suffix)))))
 
 (defn- finalize-line [line]
-  (if (string? (first line))
-    (tufte/p
-     ::finalize-line-string
-     line)
-
-    (tufte/p
-     ::finalize-line-parser
-     (-> (.stringify AnsiParser (to-array line))
+  (tufte/p
+   ::finalize-line-parser
+   (-> (.stringify AnsiParser (to-array line))
           ; This trailing "reset styles" is "nice" but unnecessary.
           ; ink should handle it for us, so keeping it is just noise
-         (trim-suffix "\u001B[0m")))))
+       (trim-suffix "\u001B[0m"))))
 
 (defn- is-space? [part]
   (= " " (.-content part)))
@@ -40,7 +35,7 @@
           (remove #(is-space? (first %)))
           (map count))))))
 
-(defn wrap-ansi-chars [ansi-chars width]
+(defn- wrap-ansi-chars-internal [finalize ansi-chars width]
   {:pre [(number? width)]}
   (loop [lines []
          current-line []
@@ -50,7 +45,7 @@
 
     (if (empty? ansi-chars)
       ; Done!
-      (conj lines (finalize-line current-line))
+      (conj lines (finalize current-line))
 
       (let [word-len (first word-lengths)
             want-to-take (inc word-len)
@@ -63,7 +58,7 @@
         (if (> (+ current-line-width word-len 1)
                width)
           ; Wrap
-          (recur (conj lines (finalize-line current-line))
+          (recur (conj lines (finalize current-line))
                  (into [] (take to-take ansi-chars))
                  ; (to-array (take to-take ansi-chars))
                  to-take ; new line initial length
@@ -78,7 +73,10 @@
                  (drop to-take ansi-chars)
                  next-word-lengths))))))
 
+(defn wrap-ansi-chars [ansi-chars width]
+  (wrap-ansi-chars-internal identity ansi-chars width))
+
 (defn wrap-ansi [s width]
   (tufte/p
    ::wrap-ansi
-   (wrap-ansi-chars (->ansi-chars s) width)))
+   (wrap-ansi-chars-internal finalize-line (->ansi-chars s) width)))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -18,7 +18,8 @@
        (trim-suffix "\u001B[0m"))))
 
 (defn- is-space? [part]
-  (= " " (.-content part)))
+  (= " " (or (.-value part)
+             (.-content part))))
 
 (defn- ->ansi-chars [^String s]
   (tufte/p
@@ -31,6 +32,7 @@
    (->> ansi-chars
         (sequence
          (comp
+          (remove #(= "ansi" (.-type %)))
           (partition-by is-space?)
           (remove #(is-space? (first %)))
           (map count))))))

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -1,8 +1,6 @@
 (ns saya.modules.buffers.line
   (:require
-   ["ansi-parser" :default AnsiParser]
    ["strip-ansi" :default strip-ansi]
-   [applied-science.js-interop :as j]
    [clojure.string :as str]
    [saya.modules.ansi.split :as split]
    [saya.modules.ansi.wrap :refer [wrap-ansi-chars]]
@@ -183,11 +181,12 @@
             (:wrapped)
             (second)))))
 
-(defn- ->ansi-continuation [ansi]
-  (when-let [parts (seq (.parse AnsiParser (str ansi " ")))]
-    (let [ansi (j/get (nth parts (dec (count parts))) :style)]
-      (when (seq ansi)
-        ansi))))
+(defn- ->ansi-continuation [^BufferLine buffer-line]
+  (when-some [ch (some->> (ansi-chars buffer-line)
+                          (seq)
+                          (last))]
+    (when (string? ch)
+      (subs ch 0 (dec (count ch))))))
 
 (defn- clean-part [o]
   (cond
@@ -200,13 +199,6 @@
       (update :plain strip-unprintable))
 
     :else o))
-
-(defn- concat->str [parts xducer]
-  (transduce
-   xducer
-   str
-   ""
-   parts))
 
 (deftype BufferLine [parts state]
   Object
@@ -264,7 +256,7 @@
   (ansi-continuation [this]
     ; NOTE: We don't cache this because we *shouldn't* need it
     ; more than once per line anyway
-    (->ansi-continuation (->ansi this))))
+    (->ansi-continuation this)))
 
 (extend-protocol IPrintWithWriter
   BufferLine

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -126,10 +126,6 @@
           (fn [group]
             (if (string? (first group))
               {:strings
-               #_(->> (wrap-ansi
-                       (str/join group)
-                       width)
-                      (map split/chars-with-ansi))
                (wrap-ansi-chars
                 (mapcat split/chars-with-ansi group)
                 width)}

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -20,31 +20,35 @@
 
 (declare ->BufferLine BufferLine)
 
+(def ^:private EMPTY-PARTS [{:ansi "" :plain ""}])
+
 (defn- strip-unprintable [s]
   (str/replace s "\u0000" ""))
 
-(defn- ->ansi-chars [parts]
-  (->> parts
-       (map (fn [{:keys [ansi system]}]
-              (or system ansi)))
-       (partition-by string?)
-       (reduce
-        (fn [formatted group]
-          (concat
-           formatted
-           (if (string? (first group))
-             (split/chars-with-ansi
-              (str/join group))
-
-             group)))
-        [])))
+(defn- tokenized-parts [^BufferLine buffer-line]
+  (or (:tokens @(.-state buffer-line))
+      (:tokens (swap! (.-state buffer-line)
+                      assoc
+                      :tokens
+                      (->> (or (.-parts buffer-line)
+                               EMPTY-PARTS)
+                           (transduce
+                            (comp
+                             (map (fn [{:keys [ansi system]}]
+                                    (or system ansi)))
+                             (partition-by string?)
+                             (mapcat
+                              (fn [group]
+                                (if (string? (first group))
+                                  (mapcat split/->ansi-tokens
+                                          group)
+                                  group))))
+                            conj []))))))
 
 (defn- part->plain [{:keys [ansi plain]}]
   (or plain
       (when ansi
         (strip-ansi ansi))))
-
-(def ^:private EMPTY-PARTS [{:ansi "" :plain ""}])
 
 (defn- compose-systems-onto-prior-strings []
   (fn [rf]
@@ -113,24 +117,21 @@
            (vreset! last-line with-col)
            (rf result with-col)))))))
 
-(defn- ->wrapped-lines [parts width]
-  (->> (or (seq parts)
-           EMPTY-PARTS)
+(defn- ->wrapped-lines [^BufferLine buffer-line width]
+  (->> (tokenized-parts buffer-line)
 
        (sequence
         (comp
-         (map (fn [{:keys [ansi system]}]
-                (or system ansi)))
          (partition-by string?)
          (map
           (fn [group]
-            (if (string? (first group))
+            (if (vector? (first group))
+              {:systems group}
+
               {:strings
                (wrap-ansi-chars
-                (mapcat split/chars-with-ansi group)
-                width)}
-
-              {:systems group})))
+                (split/tokens->chars-with-ansi group)
+                width)})))
 
        ; From above, `strings` will be a sequence of split lines,
        ; with each line being a sequence of chars-with-ansi;
@@ -155,7 +156,7 @@
 (defn- perform-line-wrap [^BufferLine buffer-line width]
   (tufte/p
    ::perform-line-wrap
-   (cond-> (->wrapped-lines (.-parts buffer-line) width)
+   (cond-> (->wrapped-lines buffer-line width)
      ; When profiling, it's easier to associate cost if we
      ; materialize upfront instead of staying lazy
      (seq js/process.env.PROFILE)
@@ -178,11 +179,11 @@
             (second)))))
 
 (defn- ->ansi-continuation [^BufferLine buffer-line]
-  (when-some [ch (some->> (ansi-chars buffer-line)
-                          (seq)
-                          (last))]
-    (when (string? ch)
-      (subs ch 0 (dec (count ch))))))
+  (let [tokens (tokenized-parts buffer-line)
+        last-tok (peek tokens)]
+    (when last-tok
+      (when (= "ansi" (.-type last-tok))
+        (.-code last-tok)))))
 
 (defn- clean-part [o]
   (cond
@@ -235,9 +236,9 @@
         (:plain (swap! state assoc :plain (->> (keep part->plain parts)
                                                (str/join))))))
 
-  (ansi-chars [_]
-    (or (:chars @state)
-        (:chars (swap! state assoc :chars (->ansi-chars parts)))))
+  (ansi-chars [this]
+    (split/tokens->chars-with-ansi
+     (tokenized-parts this)))
 
   (length [this]
     (count (ansi-chars this)))

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -118,7 +118,8 @@
            (rf result with-col)))))))
 
 (defn- ->wrapped-lines [^BufferLine buffer-line width]
-  (->> (tokenized-parts buffer-line)
+  (->> (or (seq (tokenized-parts buffer-line))
+           [""])
 
        (sequence
         (comp

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -181,9 +181,15 @@
 (defn- ->ansi-continuation [^BufferLine buffer-line]
   (let [tokens (tokenized-parts buffer-line)
         last-tok (peek tokens)]
-    (when last-tok
-      (when (= "ansi" (.-type last-tok))
-        (.-code last-tok)))))
+    (or (when (and last-tok
+                   (= "ansi" (.-type last-tok)))
+          (if (= "\u001B[0m" (.-code last-tok))
+            "" ; Hacks...?
+            (.-code last-tok)))
+        (let [parts (split/tokens->chars-with-ansi tokens)
+              last-char (last parts)]
+          (println last-char)
+          (subs last-char 0 (dec (count last-char)))))))
 
 (defn- clean-part [o]
   (cond

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -5,7 +5,7 @@
    [applied-science.js-interop :as j]
    [clojure.string :as str]
    [saya.modules.ansi.split :as split]
-   [saya.modules.ansi.wrap :refer [wrap-ansi]]
+   [saya.modules.ansi.wrap :refer [wrap-ansi-chars]]
    [taoensso.tufte :as tufte]))
 
 (defprotocol IBufferLine
@@ -127,10 +127,14 @@
          (map
           (fn [group]
             (if (string? (first group))
-              {:strings (->> (wrap-ansi
-                              (str/join group)
-                              width)
-                             (map split/chars-with-ansi))}
+              {:strings
+               #_(->> (wrap-ansi
+                       (str/join group)
+                       width)
+                      (map split/chars-with-ansi))
+               (wrap-ansi-chars
+                (mapcat split/chars-with-ansi group)
+                width)}
 
               {:systems group})))
 

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -32,7 +32,7 @@
                       :tokens
                       (->> (or (.-parts buffer-line)
                                EMPTY-PARTS)
-                           (transduce
+                           (sequence
                             (comp
                              (map (fn [{:keys [ansi system]}]
                                     (or system ansi)))
@@ -42,8 +42,7 @@
                                 (if (string? (first group))
                                   (mapcat split/->ansi-tokens
                                           group)
-                                  group))))
-                            conj []))))))
+                                  group))))))))))
 
 (defn- part->plain [{:keys [ansi plain]}]
   (or plain
@@ -180,17 +179,20 @@
             (second)))))
 
 (defn- ->ansi-continuation [^BufferLine buffer-line]
-  (let [tokens (tokenized-parts buffer-line)
-        last-tok (peek tokens)]
+  (let [tokens (->> (tokenized-parts buffer-line)
+                    (take-while (complement vector?)))
+        last-tok (last tokens)]
+    ; NOTE: the last ^here and below operate on sequences.
+    ; Not the most efficient, but it's a simple way to ensure
+    ; system messages don't interfere
     (or (when (and last-tok
                    (= "ansi" (.-type last-tok)))
           (if (= "\u001B[0m" (.-code last-tok))
             "" ; Hacks...?
             (.-code last-tok)))
-        (let [parts (split/tokens->chars-with-ansi tokens)
-              last-char (last parts)]
-          (println last-char)
-          (subs last-char 0 (dec (count last-char)))))))
+        (let [parts (split/tokens->chars-with-ansi tokens)]
+          (when-some [last-char (last parts)]
+            (subs last-char 0 (dec (count last-char))))))))
 
 (defn- clean-part [o]
   (cond

--- a/src/cli/saya/util/string.cljs
+++ b/src/cli/saya/util/string.cljs
@@ -1,0 +1,9 @@
+(ns saya.util.string
+  (:require
+   [clojure.string :as str]))
+
+(defn trim-suffix [s suffix]
+  (cond-> s
+    (str/ends-with? s suffix) (subs 0 (- (count s)
+                                         (count suffix)))))
+

--- a/src/test/saya/modules/ansi/wrap_test.cljs
+++ b/src/test/saya/modules/ansi/wrap_test.cljs
@@ -4,13 +4,14 @@
    [cljs.test :refer-macros [deftest is testing]]
    [clojure.string :as str]
    [saya.modules.ansi.split :as split]
-   [saya.modules.ansi.wrap :as wrap :refer [wrap-ansi-chars]]))
+   [saya.modules.ansi.wrap :as wrap :refer [wrap-ansi-chars]]
+   [saya.util.string :as string]))
 
 (defn- simplify-line [s]
   (-> (ansi/tokenize s)
       (ansi/styledCharsFromTokens)
       (ansi/styledCharsToString)
-      (wrap/trim-suffix "\u001b[39m")))
+      (string/trim-suffix "\u001b[39m")))
 
 (defn wrap-ansi [s width]
   (-> s

--- a/src/test/saya/modules/ansi/wrap_test.cljs
+++ b/src/test/saya/modules/ansi/wrap_test.cljs
@@ -1,13 +1,31 @@
 (ns saya.modules.ansi.wrap-test
-  (:require [cljs.test :refer-macros [deftest is testing]]
-            [saya.modules.ansi.wrap :refer [wrap-ansi-chars]]
-            [saya.modules.ansi.split :as split]))
+  (:require
+   ["@alcalzone/ansi-tokenize" :as ansi]
+   [cljs.test :refer-macros [deftest is testing]]
+   [clojure.string :as str]
+   [saya.modules.ansi.split :as split]
+   [saya.modules.ansi.wrap :as wrap :refer [wrap-ansi-chars]]))
+
+(defn- simplify-line [s]
+  (-> (ansi/tokenize s)
+      (ansi/styledCharsFromTokens)
+      (ansi/styledCharsToString)
+      (#'wrap/trim-suffix "\u001b[39m")))
 
 (defn wrap-ansi [s width]
   (-> s
       (split/->ansi-tokens)
       (split/tokens->chars-with-ansi)
-      (wrap-ansi-chars width)))
+      (wrap-ansi-chars width)
+      (->> (map str/join)
+           (map simplify-line))))
+
+(deftest word-lengths-test
+  (testing "Count words"
+    (is (= [3 3 5 2 10]
+           (#'wrap/->word-lengths
+            (split/->ansi-tokens
+             "\u001b[38;5;002mFor the honor of Grayskull!"))))))
 
 (deftest wrap-ansi-test
   (testing "Wrap, preserving complex ansi"

--- a/src/test/saya/modules/ansi/wrap_test.cljs
+++ b/src/test/saya/modules/ansi/wrap_test.cljs
@@ -1,6 +1,13 @@
 (ns saya.modules.ansi.wrap-test
   (:require [cljs.test :refer-macros [deftest is testing]]
-            [saya.modules.ansi.wrap :refer [wrap-ansi]]))
+            [saya.modules.ansi.wrap :refer [wrap-ansi-chars]]
+            [saya.modules.ansi.split :as split]))
+
+(defn wrap-ansi [s width]
+  (-> s
+      (split/->ansi-tokens)
+      (split/tokens->chars-with-ansi)
+      (wrap-ansi-chars width)))
 
 (deftest wrap-ansi-test
   (testing "Wrap, preserving complex ansi"

--- a/src/test/saya/modules/ansi/wrap_test.cljs
+++ b/src/test/saya/modules/ansi/wrap_test.cljs
@@ -10,7 +10,7 @@
   (-> (ansi/tokenize s)
       (ansi/styledCharsFromTokens)
       (ansi/styledCharsToString)
-      (#'wrap/trim-suffix "\u001b[39m")))
+      (wrap/trim-suffix "\u001b[39m")))
 
 (defn wrap-ansi [s width]
   (-> s
@@ -24,8 +24,9 @@
   (testing "Count words"
     (is (= [3 3 5 2 10]
            (#'wrap/->word-lengths
-            (split/->ansi-tokens
-             "\u001b[38;5;002mFor the honor of Grayskull!"))))))
+            (-> "\u001b[38;5;002mFor the honor of Grayskull!"
+                (split/->ansi-tokens)
+                (split/tokens->chars-with-ansi)))))))
 
 (deftest wrap-ansi-test
   (testing "Wrap, preserving complex ansi"

--- a/src/test/saya/modules/buffers/line_test.cljs
+++ b/src/test/saya/modules/buffers/line_test.cljs
@@ -48,7 +48,13 @@
     (is (= [{:col 0 :line ["-" "-" "-" "-"]}]
            (->> (wrapped-lines
                  (buffer-line "----")
-                 4))))))
+                 4)))))
+
+  (testing "Handle system messages on empty lines (?)"
+    (is (= [{:col 0 :line [[:local-send "honor"]]}]
+           (-> (buffer-line "")
+               (conj {:system [:local-send "honor"]})
+               (wrapped-lines 4))))))
 
 (deftest ansi-continuation-test
   (testing "Capture final ansi"


### PR DESCRIPTION
The changes in here reduce redundant line parsing and swap out two very slow dependencies for a much more efficient one. Our slow benchmark of replaying a long session (`awake.dump.ansi` in the comments) used to be something like >110 *seconds*---it's now 6-8s! Just replaying this stream with kodachi in release mode takes about 2s, so considering the processing we do on top this feels pretty good.

I'd love to get us closer to that 2-3s range, but this seems like such a meaningful improvement that it's not worth spending any more time on right now.

- **WIP: Clean up some redundant AnsiParser invocations**
- **Experiment with replacing AnsiParser with ansi-tokenize**
- **Fix empty line handling**
- **Unify ansi handling around tokens**
- **Remove ansi-regex dependency**
- **Fix word-lengths math for ansi tokens input**
- **Clean up wrap-test for proper comparison**
- **Fix: wrap-ansi-chars handling when receiving strings**
- **Fix lines ending in ansi-clear**
- **Fix empty line preservation**
- **Fix ansi-continuation when the line ends with a system message**
- **Clean out the ansi-parser dependency**
