### PR TITLE
Significantly optimize line wrapping and ansi handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "shadow-cljs start && shadow-cljs watch :cli",
     "cli": "node resources/cli.js",
+    "cli:prof": "node --prof resources/cli.js",
     "start": "shadow-cljs start",
     "stop": "shadow-cljs stop",
     "build:release": "shadow-cljs release :cli",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,8 @@
     "ws": "^8.18.0"
   },
   "dependencies": {
+    "@alcalzone/ansi-tokenize": "^0.3.0",
     "ansi-escapes": "^7.3.0",
-    "ansi-parser": "^3.2.11",
-    "ansi-regex": "^6.1.0",
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
     "highlight.js": "11.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,15 +16,12 @@ importers:
 
   .:
     dependencies:
+      '@alcalzone/ansi-tokenize':
+        specifier: ^0.3.0
+        version: 0.3.0
       ansi-escapes:
         specifier: ^7.3.0
         version: 7.3.0
-      ansi-parser:
-        specifier: ^3.2.11
-        version: 3.2.11
-      ansi-regex:
-        specifier: ^6.1.0
-        version: 6.1.0
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
@@ -75,9 +72,6 @@ packages:
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
-
-  ansi-parser@3.2.11:
-    resolution: {integrity: sha512-HeEwCVf/pI9qQUVaTkoDBl9U/QU4RvWJ+Trg1jNSNvDzFsBAId6fHv6VLiC7HzwrOiL8uOEkO5T1eTgpnTFQfQ==}
 
   ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
@@ -299,10 +293,6 @@ packages:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
-
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -410,10 +400,6 @@ packages:
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
-
-  is-fullwidth-code-point@5.0.0:
-    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
-    engines: {node: '>=18'}
 
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
@@ -763,13 +749,11 @@ snapshots:
   '@alcalzone/ansi-tokenize@0.3.0':
     dependencies:
       ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.0.0
+      is-fullwidth-code-point: 5.1.0
 
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
-
-  ansi-parser@3.2.11: {}
 
   ansi-regex@6.1.0: {}
 
@@ -1034,8 +1018,6 @@ snapshots:
 
   get-east-asian-width@1.2.0: {}
 
-  get-east-asian-width@1.4.0: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.2.4:
@@ -1169,13 +1151,9 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-fullwidth-code-point@5.0.0:
-    dependencies:
-      get-east-asian-width: 1.4.0
-
   is-fullwidth-code-point@5.1.0:
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.6.0
 
   is-in-ci@2.0.0: {}
 

--- a/src/cli/saya/modules/ansi/split.cljs
+++ b/src/cli/saya/modules/ansi/split.cljs
@@ -1,40 +1,17 @@
 (ns saya.modules.ansi.split
   (:require
-   ["ansi-regex" :default ansi-regex]))
+   ["@alcalzone/ansi-tokenize" :as ansi]
+   [applied-science.js-interop :as j]))
 
-(defn chars-with-ansi [s]
-  {:pre [(string? s)]}
-  (let [regex (ansi-regex)]
-    (loop [start 0
-           pending-ansi nil
-           result []]
-      (let [m (.exec regex s)
-            ansi (get m 0)
-            end (if ansi
-                  (.-lastIndex regex)
-                  (count s))
-            without-ansi (subs s start (- end
-                                          (count ansi)))
-            new-result (if (and (seq without-ansi) pending-ansi)
-                         (-> result
-                             (conj (str pending-ansi
-                                        (first without-ansi)))
-                             (into (next without-ansi)))
+(defn ->ansi-tokens [^String s]
+  (ansi/tokenize s))
 
-                         (into result without-ansi))]
-        (cond
-          ansi
-          (recur end
-                 ansi
-                 new-result)
-
-          ; If there's a pending ansi at the end, tack it onto
-          ; the last visible character
-          (and pending-ansi (seq new-result))
-          (update new-result (dec (count new-result)) str pending-ansi)
-
-          pending-ansi
-          [pending-ansi]
-
-          :else
-          new-result)))))
+(defn tokens->chars-with-ansi [toks]
+  (concat
+   (->> toks
+        (take-while (complement vector?))
+        (ansi/styledCharsFromTokens)
+        (map (j/fn [^:js {:keys [value styles]}]
+               (str (ansi/ansiCodesToString styles)
+                    value))))
+   (drop-while (complement vector?) toks)))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -1,29 +1,10 @@
 (ns saya.modules.ansi.wrap
   (:require
-   ["ansi-parser" :default AnsiParser]
    [clojure.string :as str]
    [taoensso.tufte :as tufte]))
 
-(defn- trim-suffix [s suffix]
-  (cond-> s
-    (str/ends-with? s suffix) (subs 0 (- (count s)
-                                         (count suffix)))))
-
-(defn- finalize-line [line]
-  (tufte/p
-   ::finalize-line
-   (-> (.stringify AnsiParser (to-array line))
-        ; This trailing "reset styles" is "nice" but unnecessary.
-        ; ink should handle it for us, so keeping it is just noise
-       (trim-suffix "\u001B[0m"))))
-
 (defn- is-space? [part]
-  (= " " (.-content part)))
-
-(defn- ->ansi-chars [^String s]
-  (tufte/p
-   ::ansi-chars
-   (seq (.parse AnsiParser s))))
+  (str/ends-with? part " "))
 
 (defn- ->word-lengths [ansi-chars]
   (tufte/p
@@ -35,17 +16,17 @@
           (remove #(is-space? (first %)))
           (map count))))))
 
-(defn- do-wrap-ansi [s width]
+(defn wrap-ansi-chars [ansi-chars width]
   {:pre [(number? width)]}
   (loop [lines []
          current-line []
          current-line-width 0
-         ansi-chars (->ansi-chars s)
+         ansi-chars ansi-chars
          word-lengths (->word-lengths ansi-chars)]
 
     (if (empty? ansi-chars)
       ; Done!
-      (conj lines (finalize-line current-line))
+      (conj lines current-line)
 
       (let [word-len (first word-lengths)
             want-to-take (inc word-len)
@@ -58,22 +39,15 @@
         (if (> (+ current-line-width word-len 1)
                width)
           ; Wrap
-          (recur (conj lines (finalize-line current-line))
+          (recur (conj lines current-line)
                  (into [] (take to-take ansi-chars))
-                 ; (to-array (take to-take ansi-chars))
                  to-take ; new line initial length
                  (drop to-take ansi-chars)
                  next-word-lengths)
 
           ; Continue on line
           (recur lines
-                 ; (into current-line (take to-take ansi-chars))
                  (into current-line (take to-take ansi-chars))
                  (+ current-line-width to-take)
                  (drop to-take ansi-chars)
                  next-word-lengths))))))
-
-(defn wrap-ansi [s width]
-  (tufte/p
-   ::wrap-ansi
-   (do-wrap-ansi s width)))

--- a/src/cli/saya/modules/ansi/wrap.cljs
+++ b/src/cli/saya/modules/ansi/wrap.cljs
@@ -1,7 +1,6 @@
 (ns saya.modules.ansi.wrap
   (:require
    ["ansi-parser" :default AnsiParser]
-   ["strip-ansi" :default strip-ansi]
    [clojure.string :as str]
    [taoensso.tufte :as tufte]))
 
@@ -18,14 +17,32 @@
         ; ink should handle it for us, so keeping it is just noise
        (trim-suffix "\u001B[0m"))))
 
+(defn- is-space? [part]
+  (= " " (.-content part)))
+
+(defn- ->ansi-chars [^String s]
+  (tufte/p
+   ::ansi-chars
+   (seq (.parse AnsiParser s))))
+
+(defn- ->word-lengths [ansi-chars]
+  (tufte/p
+   ::word-lengths
+   (->> ansi-chars
+        (sequence
+         (comp
+          (partition-by is-space?)
+          (remove #(is-space? (first %)))
+          (map count))))))
+
 (defn- do-wrap-ansi [s width]
   {:pre [(number? width)]}
   (loop [lines []
          current-line []
          current-line-width 0
-         word-lengths (map count
-                           (str/split (strip-ansi s) #" "))
-         ansi-chars (seq (.parse AnsiParser s))]
+         ansi-chars (->ansi-chars s)
+         word-lengths (->word-lengths ansi-chars)]
+
     (if (empty? ansi-chars)
       ; Done!
       (conj lines (finalize-line current-line))
@@ -45,16 +62,16 @@
                  (into [] (take to-take ansi-chars))
                  ; (to-array (take to-take ansi-chars))
                  to-take ; new line initial length
-                 next-word-lengths
-                 (drop to-take ansi-chars))
+                 (drop to-take ansi-chars)
+                 next-word-lengths)
 
           ; Continue on line
           (recur lines
                  ; (into current-line (take to-take ansi-chars))
                  (into current-line (take to-take ansi-chars))
                  (+ current-line-width to-take)
-                 next-word-lengths
-                 (drop to-take ansi-chars)))))))
+                 (drop to-take ansi-chars)
+                 next-word-lengths))))))
 
 (defn wrap-ansi [s width]
   (tufte/p

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -1,11 +1,9 @@
 (ns saya.modules.buffers.line
   (:require
-   ["ansi-parser" :default AnsiParser]
    ["strip-ansi" :default strip-ansi]
-   [applied-science.js-interop :as j]
    [clojure.string :as str]
    [saya.modules.ansi.split :as split]
-   [saya.modules.ansi.wrap :refer [wrap-ansi]]
+   [saya.modules.ansi.wrap :refer [wrap-ansi-chars]]
    [taoensso.tufte :as tufte]))
 
 (defprotocol IBufferLine
@@ -22,31 +20,34 @@
 
 (declare ->BufferLine BufferLine)
 
+(def ^:private EMPTY-PARTS [{:ansi "" :plain ""}])
+
 (defn- strip-unprintable [s]
   (str/replace s "\u0000" ""))
 
-(defn- ->ansi-chars [parts]
-  (->> parts
-       (map (fn [{:keys [ansi system]}]
-              (or system ansi)))
-       (partition-by string?)
-       (reduce
-        (fn [formatted group]
-          (concat
-           formatted
-           (if (string? (first group))
-             (split/chars-with-ansi
-              (str/join group))
-
-             group)))
-        [])))
+(defn- tokenized-parts [^BufferLine buffer-line]
+  (or (:tokens @(.-state buffer-line))
+      (:tokens (swap! (.-state buffer-line)
+                      assoc
+                      :tokens
+                      (->> (or (.-parts buffer-line)
+                               EMPTY-PARTS)
+                           (sequence
+                            (comp
+                             (map (fn [{:keys [ansi system]}]
+                                    (or system ansi)))
+                             (partition-by string?)
+                             (mapcat
+                              (fn [group]
+                                (if (string? (first group))
+                                  (mapcat split/->ansi-tokens
+                                          group)
+                                  group))))))))))
 
 (defn- part->plain [{:keys [ansi plain]}]
   (or plain
       (when ansi
         (strip-ansi ansi))))
-
-(def ^:private EMPTY-PARTS [{:ansi "" :plain ""}])
 
 (defn- compose-systems-onto-prior-strings []
   (fn [rf]
@@ -115,24 +116,22 @@
            (vreset! last-line with-col)
            (rf result with-col)))))))
 
-(defn- ->wrapped-lines [parts width]
-  (->> (or (seq parts)
-           EMPTY-PARTS)
+(defn- ->wrapped-lines [^BufferLine buffer-line width]
+  (->> (or (seq (tokenized-parts buffer-line))
+           [""])
 
        (sequence
         (comp
-         (map (fn [{:keys [ansi system]}]
-                (or system ansi)))
          (partition-by string?)
          (map
           (fn [group]
-            (if (string? (first group))
-              {:strings (->> (wrap-ansi
-                              (str/join group)
-                              width)
-                             (map split/chars-with-ansi))}
+            (if (vector? (first group))
+              {:systems group}
 
-              {:systems group})))
+              {:strings
+               (wrap-ansi-chars
+                (split/tokens->chars-with-ansi group)
+                width)})))
 
        ; From above, `strings` will be a sequence of split lines,
        ; with each line being a sequence of chars-with-ansi;
@@ -157,7 +156,7 @@
 (defn- perform-line-wrap [^BufferLine buffer-line width]
   (tufte/p
    ::perform-line-wrap
-   (cond-> (->wrapped-lines (.-parts buffer-line) width)
+   (cond-> (->wrapped-lines buffer-line width)
      ; When profiling, it's easier to associate cost if we
      ; materialize upfront instead of staying lazy
      (seq js/process.env.PROFILE)
@@ -179,11 +178,21 @@
             (:wrapped)
             (second)))))
 
-(defn- ->ansi-continuation [ansi]
-  (when-let [parts (seq (.parse AnsiParser (str ansi " ")))]
-    (let [ansi (j/get (nth parts (dec (count parts))) :style)]
-      (when (seq ansi)
-        ansi))))
+(defn- ->ansi-continuation [^BufferLine buffer-line]
+  (let [tokens (->> (tokenized-parts buffer-line)
+                    (take-while (complement vector?)))
+        last-tok (last tokens)]
+    ; NOTE: the last ^here and below operate on sequences.
+    ; Not the most efficient, but it's a simple way to ensure
+    ; system messages don't interfere
+    (or (when (and last-tok
+                   (= "ansi" (.-type last-tok)))
+          (if (= "\u001B[0m" (.-code last-tok))
+            "" ; Hacks...?
+            (.-code last-tok)))
+        (let [parts (split/tokens->chars-with-ansi tokens)]
+          (when-some [last-char (last parts)]
+            (subs last-char 0 (dec (count last-char))))))))
 
 (defn- clean-part [o]
   (cond
@@ -196,13 +205,6 @@
       (update :plain strip-unprintable))
 
     :else o))
-
-(defn- concat->str [parts xducer]
-  (transduce
-   xducer
-   str
-   ""
-   parts))
 
 (deftype BufferLine [parts state]
   Object
@@ -243,9 +245,9 @@
         (:plain (swap! state assoc :plain (->> (keep part->plain parts)
                                                (str/join))))))
 
-  (ansi-chars [_]
-    (or (:chars @state)
-        (:chars (swap! state assoc :chars (->ansi-chars parts)))))
+  (ansi-chars [this]
+    (split/tokens->chars-with-ansi
+     (tokenized-parts this)))
 
   (length [this]
     (count (ansi-chars this)))
@@ -260,7 +262,7 @@
   (ansi-continuation [this]
     ; NOTE: We don't cache this because we *shouldn't* need it
     ; more than once per line anyway
-    (->ansi-continuation (->ansi this))))
+    (->ansi-continuation this)))
 
 (extend-protocol IPrintWithWriter
   BufferLine

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -48,24 +48,58 @@
 
 (def ^:private EMPTY-PARTS [{:ansi "" :plain ""}])
 
+(defn- compose-systems-onto-prior-strings []
+  (fn [rf]
+    (let [last-line (volatile! nil)
+          feed-last-line (fn [result l]
+                           (reduce rf result l))]
+      (fn
+        ([] (rf))
+        ([result]
+         (if-some [l @last-line]
+           (rf (feed-last-line result l))
+           (rf result)))
+        ([result {:keys [strings systems]}]
+         (let [l @last-line]
+           (cond
+             strings
+             (let [result (if (some? l)
+                            (feed-last-line result l)
+                            result)]
+               ; Store for later
+               (vreset! last-line strings)
+               result)
+
+             (and systems (some? l))
+             (let [with-system (vec l)
+                   with-system (update with-system
+                                       (dec (count with-system))
+                                       into
+                                       systems)]
+               (vreset! last-line nil)
+               (reduce rf result with-system))
+
+             :else
+             (rf result systems))))))))
+
 (defn- ->wrapped-lines [parts width]
   (->> (or (seq parts)
            EMPTY-PARTS)
-       (map (fn [{:keys [ansi system]}]
-              (or system ansi)))
-       (partition-by string?)
 
-       (map
-        (fn [group]
-          (if (string? (first group))
-            {:strings (->> (wrap-ansi
-                            (apply str group)
-                            width)
-                           (map split/chars-with-ansi))}
+       (sequence
+        (comp
+         (map (fn [{:keys [ansi system]}]
+                (or system ansi)))
+         (partition-by string?)
+         (map
+          (fn [group]
+            (if (string? (first group))
+              {:strings (->> (wrap-ansi
+                              (apply str group)
+                              width)
+                             (map split/chars-with-ansi))}
 
-            {:systems group})))
-
-       ; NOTE: These double vector is a bit itchy... can we do better?
+              {:systems group})))
 
        ; From above, `strings` will be a sequence of split lines,
        ; with each line being a sequence of chars-with-ansi;
@@ -76,15 +110,7 @@
        ; line sequence (if any). This does mean that on a narrow
        ; screen a trailing system message could get clipped, but
        ; that's probably fine.
-       (reduce
-        (fn [result {:keys [strings systems]}]
-          (if strings
-            (into result strings)
-            (conj (if (seq result)
-                    (pop result)
-                    result)
-                  (concat (peek result) systems))))
-        [])
+         (compose-systems-onto-prior-strings)))
 
        (reduce
         (fn [result line]

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -36,7 +36,7 @@
            formatted
            (if (string? (first group))
              (split/chars-with-ansi
-              (apply str group))
+              (str/join group))
 
              group)))
         [])))
@@ -128,7 +128,7 @@
           (fn [group]
             (if (string? (first group))
               {:strings (->> (wrap-ansi
-                              (apply str group)
+                              (str/join group)
                               width)
                              (map split/chars-with-ansi))}
 
@@ -197,6 +197,13 @@
 
     :else o))
 
+(defn- concat->str [parts xducer]
+  (transduce
+   xducer
+   str
+   ""
+   parts))
+
 (deftype BufferLine [parts state]
   Object
   (equiv [this other]
@@ -229,12 +236,12 @@
   (->ansi [_]
     (or (:ansi @state)
         (:ansi (swap! state assoc :ansi (->> (keep :ansi parts)
-                                             (apply str))))))
+                                             (str/join))))))
 
   (->plain [_]
     (or (:plain @state)
         (:plain (swap! state assoc :plain (->> (keep part->plain parts)
-                                               (apply str))))))
+                                               (str/join))))))
 
   (ansi-chars [_]
     (or (:chars @state)

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -82,6 +82,39 @@
              :else
              (rf result systems))))))))
 
+(defn- drop-empty-lines-followed-by-others []
+  (fn [rf]
+    (let [last-line (volatile! nil)]
+      (fn
+        ([] (rf))
+        ([result]
+         (if-some [l @last-line]
+           (rf (rf result l))
+           (rf result)))
+        ([result line]
+         (let [l @last-line
+               result (if (seq l)
+                        (rf result l)
+                        result)]
+           (vreset! last-line line)
+           result))))))
+
+(defn- compose-col-numbers []
+  ; Each subsequent chunk should have the appropriate :col
+  ; value based on the length of the prior chunks
+  (fn [rf]
+    (let [last-line (volatile! nil)]
+      (fn
+        ([] (rf))
+        ([result] (rf result))
+        ([result line]
+         (let [l @last-line
+               with-col {:col (+ (count (:line l))
+                                 (:col l 0))
+                         :line line}]
+           (vreset! last-line with-col)
+           (rf result with-col)))))))
+
 (defn- ->wrapped-lines [parts width]
   (->> (or (seq parts)
            EMPTY-PARTS)
@@ -110,34 +143,25 @@
        ; line sequence (if any). This does mean that on a narrow
        ; screen a trailing system message could get clipped, but
        ; that's probably fine.
-         (compose-systems-onto-prior-strings)))
+         (compose-systems-onto-prior-strings)
 
-       (reduce
-        (fn [result line]
-          (let [last-line (peek result)]
-            (cond-> result
-              ; When doing a hard split, we might end up with eg:
-              ; [{:col 0 :line []}
-              ;  {:col 0 :line ["-" "-" ..]}]
-              ; This collapses that useless bit on the same
-              ; column.
-              ; TODO: would be better to fix upstream, but this
-              ; prevents react complaining about duplicate keys
-              ; until then.
-              (and last-line
-                   (empty? (:line last-line)))
-              (pop)
+         ; When doing a hard split, we might end up with eg:
+         ; [{:col 0 :line []}
+         ;  {:col 0 :line ["-" "-" ..]}]
+         ; This collapses that useless bit on the same
+         ; column.
+         (drop-empty-lines-followed-by-others)
 
-              :always
-              (conj {:col (+ (count (:line (peek result)))
-                             (:col (peek result) 0))
-                     :line line}))))
-        [])))
+         (compose-col-numbers)))))
 
 (defn- perform-line-wrap [^BufferLine buffer-line width]
   (tufte/p
    ::perform-line-wrap
-   (->wrapped-lines (.-parts buffer-line) width)
+   (cond-> (->wrapped-lines (.-parts buffer-line) width)
+     ; When profiling, it's easier to associate cost if we
+     ; materialize upfront instead of staying lazy
+     (seq js/process.env.PROFILE)
+     (vec))
    #_[{:line (into (wrap-ansi (->ansi buffer-line) width)
                    (keep :system (.-parts buffer-line)))
        :col 0}]))

--- a/src/cli/saya/util/string.cljs
+++ b/src/cli/saya/util/string.cljs
@@ -1,0 +1,9 @@
+(ns saya.util.string
+  (:require
+   [clojure.string :as str]))
+
+(defn trim-suffix [s suffix]
+  (cond-> s
+    (str/ends-with? s suffix) (subs 0 (- (count s)
+                                         (count suffix)))))
+

--- a/src/test/saya/modules/ansi/wrap_test.cljs
+++ b/src/test/saya/modules/ansi/wrap_test.cljs
@@ -1,6 +1,33 @@
 (ns saya.modules.ansi.wrap-test
-  (:require [cljs.test :refer-macros [deftest is testing]]
-            [saya.modules.ansi.wrap :refer [wrap-ansi]]))
+  (:require
+   ["@alcalzone/ansi-tokenize" :as ansi]
+   [cljs.test :refer-macros [deftest is testing]]
+   [clojure.string :as str]
+   [saya.modules.ansi.split :as split]
+   [saya.modules.ansi.wrap :as wrap :refer [wrap-ansi-chars]]
+   [saya.util.string :as string]))
+
+(defn- simplify-line [s]
+  (-> (ansi/tokenize s)
+      (ansi/styledCharsFromTokens)
+      (ansi/styledCharsToString)
+      (string/trim-suffix "\u001b[39m")))
+
+(defn wrap-ansi [s width]
+  (-> s
+      (split/->ansi-tokens)
+      (split/tokens->chars-with-ansi)
+      (wrap-ansi-chars width)
+      (->> (map str/join)
+           (map simplify-line))))
+
+(deftest word-lengths-test
+  (testing "Count words"
+    (is (= [3 3 5 2 10]
+           (#'wrap/->word-lengths
+            (-> "\u001b[38;5;002mFor the honor of Grayskull!"
+                (split/->ansi-tokens)
+                (split/tokens->chars-with-ansi)))))))
 
 (deftest wrap-ansi-test
   (testing "Wrap, preserving complex ansi"

--- a/src/test/saya/modules/buffers/line_test.cljs
+++ b/src/test/saya/modules/buffers/line_test.cljs
@@ -48,7 +48,13 @@
     (is (= [{:col 0 :line ["-" "-" "-" "-"]}]
            (->> (wrapped-lines
                  (buffer-line "----")
-                 4))))))
+                 4)))))
+
+  (testing "Handle system messages on empty lines (?)"
+    (is (= [{:col 0 :line [[:local-send "honor"]]}]
+           (-> (buffer-line "")
+               (conj {:system [:local-send "honor"]})
+               (wrapped-lines 4))))))
 
 (deftest ansi-continuation-test
   (testing "Capture final ansi"


### PR DESCRIPTION
The changes in here reduce redundant line parsing and swap out two very slow dependencies for a much more efficient one. Our slow benchmark of replaying a long session (`awake.dump.ansi` in the comments) used to be something like >110 *seconds*---it's now 6-8s! Just replaying this stream with kodachi in release mode takes about 2s, so considering the processing we do on top this feels pretty good.

I'd love to get us closer to that 2-3s range, but this seems like such a meaningful improvement that it's not worth spending any more time on right now.

- **WIP: Clean up some redundant AnsiParser invocations**
- **Experiment with replacing AnsiParser with ansi-tokenize**
- **Fix empty line handling**
- **Unify ansi handling around tokens**
- **Remove ansi-regex dependency**
- **Fix word-lengths math for ansi tokens input**
- **Clean up wrap-test for proper comparison**
- **Fix: wrap-ansi-chars handling when receiving strings**
- **Fix lines ending in ansi-clear**
- **Fix empty line preservation**
- **Fix ansi-continuation when the line ends with a system message**
- **Clean out the ansi-parser dependency**