### PR TITLE
Support persisted input

### DIFF
--- a/src/cli/saya/modules/command/registry/connection.cljs
+++ b/src/cli/saya/modules/command/registry/connection.cljs
@@ -6,11 +6,22 @@
    [saya.modules.kodachi.events :as kodachi-events]
    [saya.util.string :as string]))
 
+(defn make-persistence-key [input {:keys [script-file uri]}]
+  (when input
+    (string/slugify
+     (or
+      (when (string? input)
+        input)
+      (str script-file
+           "-"
+           uri)))))
+
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (reg-event-fx
  :command/connect
  [(aliases :c :co :con :conn) unwrap]
- (fn [_ {[uri-param] :params :keys [uri auto-prompts persist-output
+ (fn [_ {[uri-param] :params :keys [uri auto-prompts nonce
+                                    persist-input persist-output
                                     script-file]}]
    ; NOTE: This may be invoked either as:
    ;   [:command/connect {:uri uri}]
@@ -23,15 +34,16 @@
                        "legendsofthejedi.com:5656"))]
      {:dispatch [::kodachi-events/connect
                  {:uri the-uri
+                  :nonce nonce
                   :auto_prompts auto-prompts
-                  :persisted_output_key (when persist-output
-                                          (string/slugify
-                                           (or
-                                            (when (string? persist-output)
-                                              persist-output)
-                                            (str script-file
-                                                 "-"
-                                                 the-uri))))}]})))
+                  :persisted_output_key (make-persistence-key
+                                         persist-output
+                                         {:script-file script-file
+                                          :uri the-uri})
+                  :persisted_input_key (make-persistence-key
+                                        persist-input
+                                        {:script-file script-file
+                                         :uri the-uri})}]})))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (reg-event-fx

--- a/src/cli/saya/modules/input/events.cljs
+++ b/src/cli/saya/modules/input/events.cljs
@@ -41,7 +41,7 @@
  ::on-load-history-for-connection
  [unwrap]
  (fn [db {:keys [connr entries]}]
-   (let [bufnr (get-in db [:connections connr :bufnr])]
+   (let [bufnr [:conn/input connr]]
      (cond-> db
        ; Don't replacing existing history (this could be a reconnect)
        (not (seq (get-in db [:histories bufnr])))

--- a/src/cli/saya/modules/input/events.cljs
+++ b/src/cli/saya/modules/input/events.cljs
@@ -36,3 +36,13 @@
    (cond-> db
      (seq (str/trim entry))
      (update-in [:histories bufnr] add-history-entry entry))))
+
+(reg-event-db
+ ::on-load-history-for-connection
+ [unwrap]
+ (fn [db {:keys [connr entries]}]
+   (let [bufnr (get-in db [:connections connr :bufnr])]
+     (cond-> db
+       ; Don't replacing existing history (this could be a reconnect)
+       (not (seq (get-in db [:histories bufnr])))
+       (assoc-in [:histories bufnr] entries)))))

--- a/src/cli/saya/modules/kodachi/api.cljs
+++ b/src/cli/saya/modules/kodachi/api.cljs
@@ -6,9 +6,9 @@
    [archetype.util :refer [>evt]]
    [promesa.core :as p]
    [saya.config :as config]
+   [saya.modules.echo.core :refer [echo]]
    [saya.modules.kodachi.events :as events]
-   [saya.modules.logging.core :refer [log]]
-   [saya.modules.scripting.core :refer [echo]]))
+   [saya.modules.logging.core :refer [log]]))
 
 (def ^:private default-paths
   ["../kodachi/target/release/kodachi"
@@ -27,12 +27,15 @@
       (.on "error" #(p/reject! promise %)))
     promise))
 
+(defonce ^:private failed-messages (atom []))
+
 (defn- parse-message [raw-message]
   (try
     (-> raw-message
         (js/JSON.parse)
         (js->clj :keywordize-keys true))
     (catch :default e
+      (swap! failed-messages conj raw-message)
       #_{:clj-kondo/ignore [:inline-def :unused-private-var]}
       (def ^:private last-message raw-message)
       #_{:clj-kondo/ignore [:inline-def :unused-private-var]}

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -12,6 +12,7 @@
    [saya.modules.input.events :as input-events]
    [saya.modules.kodachi.api :as kodachi-api]
    [saya.modules.kodachi.events :as kodachi]
+   [saya.modules.logging.core :refer [log]]
    [saya.modules.scripting.callbacks :refer [register-callback]]
    [saya.modules.scripting.events :as events]))
 
@@ -33,8 +34,8 @@
          (fn [[event-name & args] _]
            (m/match [event-name (vec args)]
              [::kodachi/connecting [{:connection-id connection-id
-                                     :nonce received-nonce
-                                     :uri uri}]]
+                                     :uri uri
+                                     :opts {:nonce received-nonce}}]]
              (when (= received-nonce nonce)
                (stop-listening)
                (p-resolve connection-id))
@@ -42,6 +43,7 @@
              :else nil)))
 
         (>evt [:command/connect {:uri uri
+                                 :nonce nonce
                                  :auto-prompts auto-prompt?
                                  :script-file script-file
                                  :persist-output persist-output?
@@ -54,6 +56,7 @@
                                        {:type :GetHistory
                                         :connection_id connection-id
                                         :limit config/history-length})]
+              (log "loaded history for " connection-id (count entries))
               (>evt [::input-events/on-load-history-for-connection
                      {:connr connection-id
                       :entries entries}])))

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -7,7 +7,10 @@
    [promesa.core :as p]
    [re-frame.core :as rf]
    [re-frame.db :as rfdb]
+   [saya.config :as config]
    [saya.modules.echo.core :as echo-core]
+   [saya.modules.input.events :as input-events]
+   [saya.modules.kodachi.api :as kodachi-api]
    [saya.modules.kodachi.events :as kodachi]
    [saya.modules.scripting.callbacks :refer [register-callback]]
    [saya.modules.scripting.events :as events]))
@@ -16,28 +19,46 @@
 
 ; ======= setup-connection =================================
 
-(defn- perform-connect [uri {:keys [auto-prompt? persist-output?]}]
+(defn- perform-connect [uri {:keys [auto-prompt? persist-output? persist-input?]}]
   (let [callback-id [::on-connection uri]
         stop-listening (fn stop-listening []
                          (rf/remove-post-event-callback callback-id))
+        nonce (str (js/Date.now) "." (js/Math.random))
         script-file *script-file*]
-    (p/create
-     (fn [p-resolve _]
-       (rf/add-post-event-callback
-        callback-id
-        (fn [[event-name & args] _]
-          (m/match [event-name (vec args)]
-            [::kodachi/connecting [{:connection-id connection-id
-                                    :uri uri}]]
-            (do (stop-listening)
-                (p-resolve connection-id))
+    (->
+     (p/create
+      (fn [p-resolve _]
+        (rf/add-post-event-callback
+         callback-id
+         (fn [[event-name & args] _]
+           (m/match [event-name (vec args)]
+             [::kodachi/connecting [{:connection-id connection-id
+                                     :nonce received-nonce
+                                     :uri uri}]]
+             (when (= received-nonce nonce)
+               (stop-listening)
+               (p-resolve connection-id))
 
-            :else nil)))
+             :else nil)))
 
-       (>evt [:command/connect {:uri uri
-                                :auto-prompts auto-prompt?
-                                :script-file script-file
-                                :persist-output persist-output?}])))))
+        (>evt [:command/connect {:uri uri
+                                 :auto-prompts auto-prompt?
+                                 :script-file script-file
+                                 :persist-output persist-output?
+                                 :persist-input persist-input?}])))
+     (p/then
+      (fn [connection-id]
+        (p/do
+          (when persist-input?
+            (p/let [{:keys [entries]} (kodachi-api/request!
+                                       {:type :GetHistory
+                                        :connection_id connection-id
+                                        :limit config/history-length})]
+              (>evt [::input-events/on-load-history-for-connection
+                     {:connr connection-id
+                      :entries entries}])))
+
+          connection-id))))))
 
 ; "Unpacks" a `conn` into a connr. For now, a no-op
 (def ^:private ->connr identity)


### PR DESCRIPTION
Builds on https://github.com/dhleong/kodachi/pull/37 to support persisting input history. As noted in the comments, we just load `GetHistory` once on connect since we already manage input history locally for purposes of the input buffer / cmdline window.

- **Try to use new kodachi persistent input history**
- **Add more reliable access to unparseable kodachi messages**
- **Fix nonce checking**
- **Fix: store loaded history under the correct key**
