### PR TITLE
Add fuzzy input history search

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "ansi-escapes": "^7.3.0",
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
+    "fzf": "^0.5.2",
     "highlight.js": "11.0.1",
     "ink": "^7.1.1",
     "ink-spinner": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       figures:
         specifier: ^3.2.0
         version: 3.2.0
+      fzf:
+        specifier: ^0.5.2
+        version: 0.5.2
       highlight.js:
         specifier: 11.0.1
         version: 11.0.1
@@ -278,6 +281,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fzf@0.5.2:
+    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -958,6 +964,8 @@ snapshots:
       is-callable: 1.2.7
 
   function-bind@1.1.2: {}
+
+  fzf@0.5.2: {}
 
   get-east-asian-width@1.6.0: {}
 

--- a/src/cli/saya/errors.cljs
+++ b/src/cli/saya/errors.cljs
@@ -1,0 +1,7 @@
+(ns saya.errors)
+
+(def invalid-in-cmdline
+  "Invalid in command-line window; <CR> executes, CTRL-C quits")
+
+(def invalid-outside-connection
+  "Invalid outside connection input buffer")

--- a/src/cli/saya/modules/completion/events.cljs
+++ b/src/cli/saya/modules/completion/events.cljs
@@ -11,6 +11,13 @@
        (update-in [:buffers bufnr :completion] dissoc :applied-candidate))))
 
 (reg-event-db
+ ::reset
+ [unwrap]
+ (fn [db {:keys [bufnr]}]
+   (-> db
+       (update-in [:buffers bufnr] dissoc :completion))))
+
+(reg-event-db
  ::on-applied-candidate
  [unwrap]
  (fn [db {:keys [bufnr candidate]}]
@@ -19,8 +26,11 @@
 (reg-event-db
  ::on-candidates
  [unwrap]
- (fn [db {:keys [bufnr candidates]}]
-   (assoc-in db [:buffers bufnr :completion :candidates] candidates)))
+ (fn [db {:keys [bufnr explicit? candidates]}]
+   (update-in db [:buffers bufnr :completion]
+              assoc
+              :candidates candidates
+              :explicit? explicit?)))
 
 (reg-event-db
  ::on-error

--- a/src/cli/saya/modules/completion/helpers.cljs
+++ b/src/cli/saya/modules/completion/helpers.cljs
@@ -4,7 +4,8 @@
    [clojure.string :as str]
    [promesa.core :as p]
    [saya.modules.completion.events :as events]
-   [saya.modules.completion.proto :as proto :refer [ICompletionSource]]
+   [saya.modules.completion.proto :as proto :refer [ICompletionSource
+                                                    IConditionalCompletionSource]]
    [saya.modules.logging.core :refer [log]]))
 
 (defn word-to-complete [{:keys [line-before-cursor]}]
@@ -22,14 +23,17 @@
 
     (let [line-before-cursor (subs line 0 cursor)
           context {:line-before-cursor line-before-cursor}
-          word-to-complete (word-to-complete context)]
+          word-to-complete (word-to-complete context)
+          explicit? (and (satisfies? IConditionalCompletionSource source)
+                         (proto/should-gather? source context))]
       (>evt [::events/start {:bufnr bufnr
                              :word-to-complete word-to-complete
                              :line-before-cursor line-before-cursor}])
-
-      (when (seq word-to-complete)
+      (when (or (seq word-to-complete)
+                explicit?)
         (-> (p/let [candidates (proto/gather-candidates source context)]
               (>evt [::events/on-candidates {:bufnr bufnr
+                                             :explicit? explicit?
                                              :candidates (seq candidates)}]))
             (p/catch (fn [e]
                        (log "ERROR in completion: " e)

--- a/src/cli/saya/modules/completion/proto.cljs
+++ b/src/cli/saya/modules/completion/proto.cljs
@@ -2,3 +2,6 @@
 
 (defprotocol ICompletionSource
   (gather-candidates [this {:keys [line-before-cursor]}]))
+
+(defprotocol IConditionalCompletionSource
+  (should-gather? [this {:keys [line-before-cursor]}]))

--- a/src/cli/saya/modules/completion/subs.cljs
+++ b/src/cli/saya/modules/completion/subs.cljs
@@ -29,21 +29,31 @@
  :-> :applied-candidate)
 
 (reg-sub
+ ::explicit?
+ :<- [::state]
+ :-> :explicit?)
+
+(reg-sub
  ::left-offset
  :<- [::applied-candidate]
  :<- [::word-to-complete]
- :-> (fn [[applied-candidate word-to-complete]]
+ :<- [::explicit?]
+ :-> (fn [[applied-candidate word-to-complete explicit?]]
        (or (when (seq applied-candidate)
              (- (count applied-candidate)))
 
            (when (seq word-to-complete)
-             (- (count word-to-complete))))))
+             (- (count word-to-complete)))
+
+           (when explicit?
+             0))))
 
 (reg-sub
  ::candidates
  :<- [::state]
- :-> (fn [{:keys [candidates word-to-complete]}]
-       (when (seq word-to-complete)
+ :-> (fn [{:keys [candidates explicit? word-to-complete]}]
+       (when (or (seq word-to-complete)
+                 explicit?)
          ; TODO: It could be nice to be able to scroll through all?
          (take 15 candidates))))
 

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -8,7 +8,6 @@
    [saya.modules.command.interceptors :refer [with-buffer-context]]
    [saya.modules.connection.events :as conn-events]
    [saya.modules.echo.events :as echo-events]
-   [saya.modules.input.events :as input-events]
    [saya.modules.input.fx :as fx]
    [saya.modules.input.helpers :refer [update-cursor]]
    [saya.modules.input.insert :as insert]

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -3,10 +3,12 @@
    [clojure.core.match :refer [match]]
    [re-frame.core :refer [reg-event-fx trim-v]]
    [saya.cli.text-input.helpers :refer [key->insertable]]
+   [saya.errors :as errors]
    [saya.modules.buffers.util :as buffers]
    [saya.modules.command.interceptors :refer [with-buffer-context]]
    [saya.modules.connection.events :as conn-events]
    [saya.modules.echo.events :as echo-events]
+   [saya.modules.input.events :as input-events]
    [saya.modules.input.fx :as fx]
    [saya.modules.input.helpers :refer [update-cursor]]
    [saya.modules.input.insert :as insert]
@@ -45,6 +47,7 @@
                               (update-cursor :col dec)))
       :db
       (or db)
+      (dissoc :history-search)
       (assoc :mode (if (:connr cofx)
                      :prompt
                      :normal))))
@@ -103,6 +106,9 @@
     [:insert :return {:submit? true}] {:dispatch [::submit-cmdline]}
     [:normal :ctrl/c {:submit? true}] {:dispatch [::cancel-cmdline]}
     [:insert :ctrl/c {:submit? true}] {:dispatch [::cancel-cmdline]}
+
+    [:insert :ctrl/r {:submit? true}] {:dispatch [:echo :error errors/invalid-in-cmdline]}
+    [:insert :ctrl/r _] {:dispatch [:echo :error errors/invalid-outside-connection]}
 
     [:normal key {:bufnr? true}]
     (keymaps/maybe-perform-with-keymap-buffer

--- a/src/cli/saya/modules/input/events.cljs
+++ b/src/cli/saya/modules/input/events.cljs
@@ -23,6 +23,13 @@
                                         :on-submit on-submit
                                         :bufnr bufnr})))))
 
+(reg-event-db
+ ::set-history-search-bufnr
+ [unwrap]
+ (fn [db {:keys [bufnr]}]
+   (-> db
+       (assoc :history-search {:bufnr bufnr}))))
+
 (defn add-history-entry [history new-entry]
   (->> history
        (filter (partial not= new-entry))

--- a/src/cli/saya/modules/input/history/search.cljs
+++ b/src/cli/saya/modules/input/history/search.cljs
@@ -1,0 +1,30 @@
+(ns saya.modules.input.history.search
+  (:require
+   ["fzf" :refer [Fzf]]
+   [applied-science.js-interop :as j]
+   [promesa.core :as p]
+   [re-frame.db :as rfdb]
+   [saya.modules.completion.proto :refer [ICompletionSource
+                                          IConditionalCompletionSource]]))
+
+(defn- perform-query [bufnr request]
+  (let [db @rfdb/app-db
+        history (get-in db [:histories bufnr])]
+    (if (seq request)
+      (-> ^js (Fzf. (to-array history))
+          (.find request)
+          (->> (map #(j/get % .-item))))
+      history)))
+
+(defrecord HistoryCompletionSource [bufnr]
+  IConditionalCompletionSource
+  (should-gather? [_this _ctx]
+    true)
+
+  ICompletionSource
+  (gather-candidates [_this {:keys [line-before-cursor]}]
+    (p/do
+      (perform-query bufnr line-before-cursor))))
+
+(comment
+  (perform-query [:conn/input 0] "he"))

--- a/src/cli/saya/modules/input/history/subs.cljs
+++ b/src/cli/saya/modules/input/history/subs.cljs
@@ -1,0 +1,12 @@
+(ns saya.modules.input.history.subs
+  (:require
+   [re-frame.core :refer [reg-sub]]))
+
+(reg-sub
+ ::history-search
+ :-> :history-search)
+
+(reg-sub
+ ::history-search-bufnr
+ :<- [::history-search]
+ :-> :bufnr)

--- a/src/cli/saya/modules/input/window.cljs
+++ b/src/cli/saya/modules/input/window.cljs
@@ -6,12 +6,14 @@
    [clojure.core.match :refer [match]]
    [reagent.core :as r]
    [saya.cli.text-input :refer [text-input]]
+   [saya.errors :as errors]
    [saya.modules.completion.events :as completion-events]
    [saya.modules.completion.helpers :refer [refresh-completion]]
    [saya.modules.completion.subs :as completion-subs]
    [saya.modules.echo.core :refer [echo]]
    [saya.modules.input.core :as input]
-   [saya.modules.input.events :as events]))
+   [saya.modules.input.events :as events]
+   [applied-science.js-interop :as j]))
 
 (defn- safely [f & args]
   (let [f (partial f args)]
@@ -32,7 +34,13 @@
                   (>evt [::events/set-cmdline-bufnr {:bufnr bufnr
                                                      :on-submit on-submit}]))
 
-                (echo :error "Invalid in command-line window; <CR> executes, CTRL-C quits"))
+                (echo :error errors/invalid-in-cmdline))
+    [:ctrl/r] (if (and (vector? bufnr)
+                       (= :conn/input (first bufnr)))
+                (>evt [::events/set-history-search-bufnr
+                       {:bufnr bufnr}])
+                (echo :error errors/invalid-in-cmdline))
+
     [:ctrl/c] (let [input @input-ref]
                 ; NOTE: ctrl-c once to clear, again to exit
                 (on-change "" 0 nil {:for-cancel? true})
@@ -43,6 +51,7 @@
     [:escape] (let [to-persist @input-ref]
                 (when on-persist-value
                   (on-persist-value to-persist {:for-cancel? true}))
+                (>evt [::completion-events/reset {:bufnr bufnr}])
                 (>evt [::input/on-key key]))
     :else nil))
 
@@ -53,13 +62,16 @@
                             add-to-history?
                             completion]
                      :or {add-to-history? true}}]
-  (r/with-let [input-ref (atom (or initial-value ""))]
+  (r/with-let [input-ref (atom (or initial-value ""))
+               cursor-ref (atom (or initial-cursor 0))]
     (let [[input set-input!] (React/useState @input-ref)
+          current-completion (React/useRef completion)
           on-change (React/useCallback
                      (fn [v cursor completion-opts change-opts]
-                       (when completion
-                         (refresh-completion completion bufnr v cursor completion-opts))
+                       (when-let [compl (.-current current-completion)]
+                         (refresh-completion compl bufnr v cursor completion-opts))
                        (set-input! v)
+                       (reset! cursor-ref cursor)
                        (when on-persist-value
                          (on-persist-value v change-opts))
                        (when on-persist-cursor
@@ -89,6 +101,19 @@
          (fn on-dismount []
            (>evt [::completion-events/unset-bufnr bufnr])))
        #js [bufnr])
+
+      (React/useEffect
+       (fn on-mount []
+         (when (and completion
+                    (not= completion (.-current current-completion)))
+           (j/assoc! current-completion .-current completion)
+           (let [s @input-ref
+                 cursor @cursor-ref
+                 before-cursor (subs s 0 cursor)]
+             (refresh-completion completion bufnr before-cursor cursor nil)))
+
+         js/undefined)
+       #js [completion])
 
       [:> k/Box
        [:> k/Text before

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -11,6 +11,8 @@
    [saya.modules.buffers.subs :as buffer-subs]
    [saya.modules.connection.completion :refer [->ConnectionCompletionSource]]
    [saya.modules.connection.events :as conn-events]
+   [saya.modules.input.history.search :refer [->HistoryCompletionSource]]
+   [saya.modules.input.history.subs :as history-subs]
    [saya.modules.input.window :as input-window]
    [saya.modules.kodachi.events :as kodachi-events]
    [saya.modules.perf.core :as perf]
@@ -57,12 +59,15 @@
                           "^^^ Restored " count " lines."])})
 
 (defn- input-window [connr]
-  (let [bufnr [:conn/input connr]]
+  (let [bufnr [:conn/input connr]
+        history-search? (= bufnr (<sub [::history-subs/history-search-bufnr]))]
     [input-window/input-window
      {:bufnr bufnr
       :initial-value (<sub [::subs/input-text connr])
       :initial-cursor (:col (<sub [::buffer-subs/buffer-cursor bufnr]))
-      :completion (->ConnectionCompletionSource connr)
+      :completion (if history-search?
+                    (->HistoryCompletionSource bufnr)
+                    (->ConnectionCompletionSource connr))
       :add-to-history? false ; Handled by submit-input-buffer
       :on-persist-value #(>evt [::window-events/set-input-text {:connr connr
                                                                 :text %}])

--- a/src/cli/saya/modules/window/view.cljs
+++ b/src/cli/saya/modules/window/view.cljs
@@ -61,27 +61,32 @@
 (defn- input-window [connr]
   (let [bufnr [:conn/input connr]
         history-search? (= bufnr (<sub [::history-subs/history-search-bufnr]))]
-    [input-window/input-window
-     {:bufnr bufnr
-      :initial-value (<sub [::subs/input-text connr])
-      :initial-cursor (:col (<sub [::buffer-subs/buffer-cursor bufnr]))
-      :completion (if history-search?
-                    (->HistoryCompletionSource bufnr)
-                    (->ConnectionCompletionSource connr))
-      :add-to-history? false ; Handled by submit-input-buffer
-      :on-persist-value #(>evt [::window-events/set-input-text {:connr connr
-                                                                :text %}])
-      :on-persist-cursor (fn [col]
-                           (>evt [::buffer-events/set-cursor
-                                  {:id bufnr
-                                   :cursor {:row 0 :col col}}]))
-      :on-prepare-buffer #(>evt [::window-events/prepare-input-cmdline-buffer
-                                 {:bufnr bufnr
-                                  :current %}])
-      :on-submit (fn [text]
-                   (>evt [::conn-events/submit-input-buffer
-                          {:connr connr
-                           :text text}]))}]))
+    [:> k/Box
+     (when history-search?
+       [:> k/Text "(reverse-i-search): "])
+
+     ^{:key bufnr}
+     [input-window/input-window
+      {:bufnr bufnr
+       :initial-value (<sub [::subs/input-text connr])
+       :initial-cursor (:col (<sub [::buffer-subs/buffer-cursor bufnr]))
+       :completion (if history-search?
+                     (->HistoryCompletionSource bufnr)
+                     (->ConnectionCompletionSource connr))
+       :add-to-history? false ; Handled by submit-input-buffer
+       :on-persist-value #(>evt [::window-events/set-input-text {:connr connr
+                                                                 :text %}])
+       :on-persist-cursor (fn [col]
+                            (>evt [::buffer-events/set-cursor
+                                   {:id bufnr
+                                    :cursor {:row 0 :col col}}]))
+       :on-prepare-buffer #(>evt [::window-events/prepare-input-cmdline-buffer
+                                  {:bufnr bufnr
+                                   :current %}])
+       :on-submit (fn [text]
+                    (>evt [::conn-events/submit-input-buffer
+                           {:connr connr
+                            :text text}]))}]]))
 
 (defn- modeful-cursor []
   (let [cursor-type (case (<sub [:mode])

--- a/src/cli/saya/views.cljs
+++ b/src/cli/saya/views.cljs
@@ -6,7 +6,6 @@
    [saya.cli.input :as input]
    [saya.modules.completion.view :refer [completion-menu]]
    [saya.modules.home.core :refer [home-view]]
-   [saya.modules.input.history.search :refer [history-search-view]]
    [saya.modules.ui.error-boundary :refer [error-boundary]]))
 
 (def ^:private pages
@@ -14,8 +13,7 @@
 
 (defn- popup-menus []
   [:<>
-   [completion-menu]
-   [history-search-view]])
+   [completion-menu]])
 
 (defn main []
   (let [[page args] (<sub [:page])

--- a/src/cli/saya/views.cljs
+++ b/src/cli/saya/views.cljs
@@ -6,6 +6,7 @@
    [saya.cli.input :as input]
    [saya.modules.completion.view :refer [completion-menu]]
    [saya.modules.home.core :refer [home-view]]
+   [saya.modules.input.history.search :refer [history-search-view]]
    [saya.modules.ui.error-boundary :refer [error-boundary]]))
 
 (def ^:private pages
@@ -13,7 +14,8 @@
 
 (defn- popup-menus []
   [:<>
-   [completion-menu]])
+   [completion-menu]
+   [history-search-view]])
 
 (defn main []
   (let [[page args] (<sub [:page])


### PR DESCRIPTION
Fixes #49

This maps `<c-r>` in insert mode of a connection input buffer to enter a mode that behaves similar to the same mapping in bash, closer but not quite to the equivalent FZF history search mode. It reuses autocomplete functionality so shares the same tab/s-tab UX to select between multiple candidates.

<img width="404" height="82" alt="Screenshot 2026-08-30 at 5 27 11 PM" src="https://github.com/user-attachments/assets/6c73cc9b-21da-4b25-936e-30fc276ee834" />

Since this is an extension of autocomplete, you can simply hit esc to return to normal mode and exit the special completion mode in a single keypress, then edit it as you will before submitting.

- **Scaffold history search as a type of completion**
- **Fix reference to old code**
- **Add a smol bit more UI to history search "mode"**
