### PR TITLE
Add copy/paste support, with system clipboard integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@alcalzone/ansi-tokenize": "^0.3.0",
     "ansi-escapes": "^7.3.0",
+    "clipboardy": "^5.3.2",
     "env-paths": "^3.0.0",
     "figures": "^3.2.0",
     "fzf": "^0.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       ansi-escapes:
         specifier: ^7.3.0
         version: 7.3.0
+      clipboardy:
+        specifier: ^5.3.2
+        version: 5.3.2
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
@@ -70,6 +73,13 @@ packages:
 
   '@alcalzone/ansi-tokenize@0.3.0':
     resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
+
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
   ansi-escapes@7.3.0:
@@ -175,6 +185,15 @@ packages:
     resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
     engines: {node: '>=22'}
 
+  clipboard-image@0.1.0:
+    resolution: {integrity: sha512-SWk7FgaXLNFld19peQ/rTe0n97lwR1WbkqxV6JKCAOh7U52AKV/PeMFCyt/8IhBdqyDA8rdyewQMKZqvWT5Akg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  clipboardy@5.3.2:
+    resolution: {integrity: sha512-R35PENCHFCw6lsd5SjYPuAVV3Zawr74mKc7ogFNzoDPoQsmWDoJgUNNnWCk/czeqdZGZs8Y0M8zkOlVoySfHEQ==}
+    engines: {node: '>=20'}
+
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -201,9 +220,17 @@ packages:
   create-hmac@1.1.7:
     resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   crypto-browserify@3.12.1:
     resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
     engines: {node: '>= 0.10'}
+
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -264,6 +291,10 @@ packages:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -271,9 +302,21 @@ packages:
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -296,6 +339,14 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -337,6 +388,14 @@ packages:
   https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -374,6 +433,11 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -383,9 +447,42 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  is-wayland@0.1.0:
+    resolution: {integrity: sha512-QkbMsWkIfkrzOPxenwye0h56iAXirZYHG9eHVPb22fO9y+wPbaX/CHacOWBa/I++4ohTcByimhM1/nyCsH8KNA==}
+    engines: {node: '>=20'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  is64bit@2.0.0:
+    resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
+    engines: {node: '>=18'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -396,12 +493,19 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  macos-version@6.0.0:
+    resolution: {integrity: sha512-O2S8voA+pMfCHhBn/TIYDXzJ1qNHpPDU32oFxglKnVdJABiYYITt45oLkV9yhwA3E2FDwn3tQqUFrTsr1p3sBQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   miller-rabin@4.0.1:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
@@ -419,6 +523,14 @@ packages:
 
   node-libs-browser@2.2.1:
     resolution: {integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -446,12 +558,24 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-browserify@0.0.1:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   pbkdf2@3.1.6:
     resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
@@ -460,6 +584,14 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
+    engines: {node: '>=20'}
+
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+    engines: {node: '>=18'}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -518,6 +650,10 @@ packages:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
     engines: {node: '>= 0.8'}
 
+  run-jxa@3.0.0:
+    resolution: {integrity: sha512-4f2CrY7H+sXkKXJn/cE6qRA3z+NMVO7zvlZ/nUV0e62yWftpiLAfw5eV9ZdomzWd2TXWwEIiGjAT57+lWIzzvA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -526,6 +662,11 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -547,6 +688,14 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -565,6 +714,10 @@ packages:
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   slice-ansi@9.0.0:
     resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
@@ -609,6 +762,22 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
+  subsume@4.0.0:
+    resolution: {integrity: sha512-BWnYJElmHbYZ/zKevy+TG+SsyoFCmRPDHJbR1MzLxkPOv1Jp/4hGhVUtP98s+wZBsBsHwCXvPTP0x287/WMjGg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  system-architecture@0.1.0:
+    resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
+    engines: {node: '>=18'}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -631,6 +800,14 @@ packages:
   tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
@@ -638,6 +815,14 @@ packages:
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
 
   untildify@5.0.0:
     resolution: {integrity: sha512-bOgQLUnd2G5rhzaTvh1VCI9Fo6bC5cLTpH17T5aFfamyXFYDbbdzN6IXdeoc3jBS7T9hNTmJtYUzJCJ2Xlc9gA==}
@@ -665,6 +850,11 @@ packages:
 
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
     hasBin: true
 
   widest-line@6.0.0:
@@ -703,6 +893,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
+
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
@@ -712,6 +906,10 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -838,6 +1036,19 @@ snapshots:
       slice-ansi: 9.0.0
       string-width: 8.2.2
 
+  clipboard-image@0.1.0:
+    dependencies:
+      run-jxa: 3.0.0
+
+  clipboardy@5.3.2:
+    dependencies:
+      clipboard-image: 0.1.0
+      execa: 9.6.1
+      is-wayland: 0.1.0
+      is-wsl: 3.1.1
+      is64bit: 2.0.0
+      powershell-utils: 0.2.1
+
   code-excerpt@4.0.0:
     dependencies:
       convert-to-spaces: 2.0.1
@@ -872,6 +1083,12 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   crypto-browserify@3.12.1:
     dependencies:
       browserify-cipher: 1.0.1
@@ -886,6 +1103,10 @@ snapshots:
       public-encrypt: 4.0.3
       randombytes: 2.1.0
       randomfill: 1.0.4
+
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
 
   define-data-property@1.1.4:
     dependencies:
@@ -948,6 +1169,8 @@ snapshots:
 
   escape-string-regexp@2.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   events@3.3.0: {}
 
   evp_bytestokey@1.0.3:
@@ -955,9 +1178,40 @@ snapshots:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.1
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   for-each@0.3.5:
     dependencies:
@@ -986,6 +1240,13 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   gopd@1.2.0: {}
 
@@ -1029,6 +1290,10 @@ snapshots:
       minimalistic-crypto-utils: 1.0.1
 
   https-browserify@1.0.0: {}
+
+  human-signals@2.1.0: {}
+
+  human-signals@8.0.1: {}
 
   ieee754@1.2.1: {}
 
@@ -1078,21 +1343,49 @@ snapshots:
 
   is-callable@1.2.7: {}
 
+  is-docker@3.0.0: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.6.0
 
   is-in-ci@2.0.0: {}
 
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
+
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.22
+
+  is-unicode-supported@2.1.0: {}
+
+  is-wayland@0.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  is64bit@2.0.0:
+    dependencies:
+      system-architecture: 0.1.0
 
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  macos-version@6.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -1101,6 +1394,8 @@ snapshots:
       hash-base: 3.0.5
       inherits: 2.0.4
       safe-buffer: 5.2.1
+
+  merge-stream@2.0.0: {}
 
   miller-rabin@4.0.1:
     dependencies:
@@ -1139,6 +1434,15 @@ snapshots:
       util: 0.11.1
       vm-browserify: 1.1.2
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -1168,9 +1472,15 @@ snapshots:
       pbkdf2: 3.1.6
       safe-buffer: 5.2.1
 
+  parse-ms@4.0.0: {}
+
   patch-console@2.0.0: {}
 
   path-browserify@0.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   pbkdf2@3.1.6:
     dependencies:
@@ -1182,6 +1492,12 @@ snapshots:
       to-buffer: 1.2.2
 
   possible-typed-array-names@1.1.0: {}
+
+  powershell-utils@0.2.1: {}
+
+  pretty-ms@9.3.1:
+    dependencies:
+      parse-ms: 4.0.0
 
   process-nextick-args@2.0.1: {}
 
@@ -1248,11 +1564,20 @@ snapshots:
       hash-base: 3.1.2
       inherits: 2.0.4
 
+  run-jxa@3.0.0:
+    dependencies:
+      execa: 5.1.1
+      macos-version: 6.0.0
+      subsume: 4.0.0
+      type-fest: 2.19.0
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
   scheduler@0.27.0: {}
+
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -1285,6 +1610,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -1314,6 +1645,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
 
   slice-ansi@9.0.0:
     dependencies:
@@ -1368,6 +1701,17 @@ snapshots:
     dependencies:
       ansi-regex: 6.3.0
 
+  strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
+
+  subsume@4.0.0:
+    dependencies:
+      escape-string-regexp: 5.0.0
+      unique-string: 3.0.0
+
+  system-architecture@0.1.0: {}
+
   tagged-tag@1.0.0: {}
 
   terminal-size@4.0.1: {}
@@ -1386,6 +1730,10 @@ snapshots:
 
   tty-browserify@0.0.0: {}
 
+  type-fest@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -1395,6 +1743,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
+
+  unicorn-magic@0.3.0: {}
+
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
 
   untildify@5.0.0: {}
 
@@ -1429,6 +1783,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   widest-line@6.0.0:
     dependencies:
       string-width: 8.2.2
@@ -1443,5 +1801,7 @@ snapshots:
   ws@8.21.3: {}
 
   xtend@4.0.2: {}
+
+  yoctocolors@2.2.0: {}
 
   yoga-layout@3.2.1: {}

--- a/src/cli/saya/db.cljs
+++ b/src/cli/saya/db.cljs
@@ -18,5 +18,7 @@
 
    :echo-history []
    :echo-cleared-at nil
-   :echo-ack-pending-since nil})
+   :echo-ack-pending-since nil
+
+   :config {}})
 

--- a/src/cli/saya/events.cljs
+++ b/src/cli/saya/events.cljs
@@ -97,3 +97,8 @@
                                    :width width
                                    :height height}}))
 
+(reg-event-db
+ :config/upsert
+ [unwrap (path :config)]
+ (fn [config new-config]
+   (merge config new-config)))

--- a/src/cli/saya/modules/buffers/line.cljs
+++ b/src/cli/saya/modules/buffers/line.cljs
@@ -277,10 +277,16 @@
 (defn buffer-line
   ([] EMPTY)
   ([initial-part]
-   (if (some? initial-part)
+   (cond
+     (instance? BufferLine initial-part)
+     initial-part
+
+     (some? initial-part)
      (->BufferLine
       [(clean-part initial-part)]
       (atom nil))
+
+     :else
      EMPTY)))
 
 (comment

--- a/src/cli/saya/modules/buffers/subs.cljs
+++ b/src/cli/saya/modules/buffers/subs.cljs
@@ -24,10 +24,13 @@
  ::current-buffer-cursor
  :<- [:buffers]
  :<- [:current-bufnr]
+ :<- [:pending-operator/from-mode]
  :<- [:mode]
- (fn [[buffers current-bufnr mode] [_ buffer-id]]
+ (fn [[buffers current-bufnr from-mode mode] [_ buffer-id]]
    (when (and (= current-bufnr buffer-id)
-              (not= :prompt mode))
+              (not= :prompt mode)
+              (not (and (= :pending-operator mode)
+                        (= :prompt from-mode))))
      (:cursor (get buffers buffer-id)))))
 
 (reg-sub

--- a/src/cli/saya/modules/input/clipboard.cljs
+++ b/src/cli/saya/modules/input/clipboard.cljs
@@ -1,0 +1,29 @@
+(ns saya.modules.input.clipboard
+  (:require
+   ["clipboardy" :default clipboardy]
+   [clojure.core.match :as m]
+   [clojure.string :as str]
+   [re-frame.core :refer [reg-fx]]
+   [saya.modules.buffers.line :refer [buffer-line]]))
+
+(defn cofx-enabled-integration? [cofx]
+  (= :unnamedplus
+     (get-in cofx [:db :config :clipboard])))
+
+(defn update-context [ctx cofx]
+  (cond-> ctx
+    (cofx-enabled-integration? cofx)
+    (assoc-in [:registers \"] (let [content (.readSync clipboardy)]
+                                (if (str/ends-with? content "\n")
+                                  {:lines (->> content
+                                               (str/split-lines)
+                                               (map buffer-line))}
+                                  {:chars content})))))
+
+(reg-fx
+ ::write
+ (fn [new-content]
+   (m/match [new-content]
+     [{:chars s}] (.write clipboardy s)
+     [{:lines s}] (.write clipboardy
+                          (str (str/join "\n" s) "\n")))))

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -87,7 +87,8 @@
                                    (buffers/readonly?
                                     (get-in db [:buffers bufnr])))
                     :connr? (some? connr)
-                    :submit? (some? (get-in db [:windows winnr :on-submit]))}]
+                    :submit? (some? (get-in db [:windows winnr :on-submit]))
+                    :op-is-read? (:read? (meta (:pending-operator db)))}]
     [(:or :normal :prompt) ":" _] {:db (assoc db :mode :command)
                                    :fx [[:dispatch [::echo-events/ack-echo]]]}
 
@@ -159,8 +160,10 @@
 
                            cofx))))
 
-    [:operator-pending key {:bufnr? true
-                            :readonly? false}]
+    [:operator-pending key (:or {:bufnr? true
+                                 :readonly? false}
+                                {:bufnr? true
+                                 :op-is-read? true})]
     (perform-operator-pending
      :cofx cofx
      :db db

--- a/src/cli/saya/modules/input/core.cljs
+++ b/src/cli/saya/modules/input/core.cljs
@@ -88,6 +88,7 @@
                                     (get-in db [:buffers bufnr])))
                     :connr? (some? connr)
                     :submit? (some? (get-in db [:windows winnr :on-submit]))
+                    :op-from-mode (:pending-operator/from-mode db)
                     :op-is-read? (:read? (meta (:pending-operator db)))}]
     [(:or :normal :prompt) ":" _] {:db (assoc db :mode :command)
                                    :fx [[:dispatch [::echo-events/ack-echo]]]}
@@ -163,6 +164,7 @@
     [:operator-pending key (:or {:bufnr? true
                                  :readonly? false}
                                 {:bufnr? true
+                                 :op-from-mode :normal
                                  :op-is-read? true})]
     (perform-operator-pending
      :cofx cofx

--- a/src/cli/saya/modules/input/helpers.cljs
+++ b/src/cli/saya/modules/input/helpers.cljs
@@ -209,5 +209,5 @@
      (extract-flags f)
      {:start start
       :end end
-      :linewise? (or (::linewise? ctx)
+      :linewise? (or (:input/linewise? ctx)
                      (not= (:row start) (:row end)))})))

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -20,7 +20,7 @@
                 f
                 (fnil str "")))))
 
-(defn- update-cursor-line-string [{:keys [buffer] :as context} f]
+(defn update-cursor-line-string [{:keys [buffer] :as context} f]
   (let [{linenr :row} (:cursor buffer)]
     (update context :buffer update-buffer-line-string linenr f)))
 

--- a/src/cli/saya/modules/input/insert.cljs
+++ b/src/cli/saya/modules/input/insert.cljs
@@ -1,12 +1,12 @@
 (ns saya.modules.input.insert
   (:require
    [saya.cli.text-input.helpers :refer [dec-to-zero split-text-by-state]]
-   [saya.modules.buffers.line :refer [buffer-line]]
+   [saya.modules.buffers.line :refer [->plain buffer-line]]
    [saya.modules.input.helpers :refer [update-cursor]]
    [saya.modules.input.shared :refer [to-end-of-line to-start-of-line]]))
 
 (defn line->string [line]
-  (str line))
+  (->plain line))
 
 (defn update-buffer-line-string [buffer linenr f]
   (cond-> buffer

--- a/src/cli/saya/modules/input/keymaps.cljs
+++ b/src/cli/saya/modules/input/keymaps.cljs
@@ -2,6 +2,7 @@
   (:require
    [saya.modules.echo.core :refer [echo-fx]]
    [saya.modules.echo.events :as echo-events]
+   [saya.modules.input.clipboard :as clipboard]
    [saya.modules.input.helpers :refer [*mode*]]))
 
 (defn- starts-with? [sequence candidate]
@@ -36,7 +37,8 @@
 
 (defn perform [{:keys [bufnr winnr] :as cofx} f]
   (try
-    (let [context (build-context cofx)
+    (let [context (-> (build-context cofx)
+                      (clipboard/update-context cofx))
           ; This merge allows us to omit unchanged fields
           context' (merge context (f context))
           yanked (:yanked context')
@@ -72,8 +74,9 @@
               (when (:mode context')
                 [:dispatch [::echo-events/ack-echo]])
 
-              ; TODO: clipboard=unnamedplus behavior
-              ]}
+              (when (and (clipboard/cofx-enabled-integration? cofx)
+                         (some? yanked))
+                [::clipboard/write yanked])]}
 
         {:db (-> (:db cofx)
                  ; Still clear this even if nothing happened:

--- a/src/cli/saya/modules/input/keymaps.cljs
+++ b/src/cli/saya/modules/input/keymaps.cljs
@@ -28,6 +28,7 @@
    :editable (when-not (= bufnr [:conn/input connr])
                (get-in cofx [:db :buffers [:conn/input connr]]))
    :pending-operator (get-in cofx [:db :pending-operator])
+   :registers (get-in cofx [:db :registers])
    :search (select-keys (get-in cofx [:db :search])
                         [:direction :query])
    :histories (get-in cofx [:db :histories])})
@@ -37,15 +38,22 @@
     (let [context (build-context cofx)
           ; This merge allows us to omit unchanged fields
           context' (merge context (f context))
-          _yanked (:yanked context')
-          context' (dissoc context' :yanked)]
+          yanked (:yanked context')
+          yanked-register (:yanked-register context' \")
+          context' (-> context'
+                       (dissoc :yanked)
+                       (cond->
+                         ; Store yanked in a register, if set
+                        (some? yanked)
+                         (assoc-in [:registers yanked-register] yanked)))]
       (if-not (= context context')
         {:db (-> (:db cofx)
                  (assoc-in [:buffers bufnr] (:buffer context'))
                  (assoc-in [:windows winnr] (:window context'))
                  (dissoc :keymap-buffer :pending-operator)
-                 ; TODO: Store yanked in a register, if set
-                 (merge (select-keys context' [:mode :pending-operator]))
+                 (merge (select-keys context' [:mode
+                                               :pending-operator
+                                               :registers]))
                  (cond->
                   (:editable context')
                    (assoc-in [:buffers (:id (:editable context'))]
@@ -58,7 +66,10 @@
                 (echo-fx :exception "ERROR:" e))
 
               (when (:mode context')
-                [:dispatch [::echo-events/ack-echo]])]}
+                [:dispatch [::echo-events/ack-echo]])
+
+              ; TODO: clipboard=unnamedplus behavior
+              ]}
 
         {:db (-> (:db cofx)
                  ; Still clear this even if nothing happened:

--- a/src/cli/saya/modules/input/keymaps.cljs
+++ b/src/cli/saya/modules/input/keymaps.cljs
@@ -22,16 +22,17 @@
    (keys keymaps)))
 
 (defn build-context [{:keys [bufnr connr winnr] :as cofx}]
-  {:buffer (get-in cofx [:db :buffers bufnr])
-   :normal-buffer (get-in cofx [:db :buffers (:normal-bufnr cofx)])
-   :window (get-in cofx [:db :windows winnr])
-   :editable (when-not (= bufnr [:conn/input connr])
-               (get-in cofx [:db :buffers [:conn/input connr]]))
-   :pending-operator (get-in cofx [:db :pending-operator])
-   :registers (get-in cofx [:db :registers])
-   :search (select-keys (get-in cofx [:db :search])
-                        [:direction :query])
-   :histories (get-in cofx [:db :histories])})
+  (merge
+   {:buffer (get-in cofx [:db :buffers bufnr])
+    :normal-buffer (get-in cofx [:db :buffers (:normal-bufnr cofx)])
+    :window (get-in cofx [:db :windows winnr])
+    :editable (when-not (= bufnr [:conn/input connr])
+                (get-in cofx [:db :buffers [:conn/input connr]]))
+    :search (select-keys (get-in cofx [:db :search])
+                         [:direction :query])}
+   (-> cofx
+       :db
+       (select-keys [:mode :pending-operator :registers :histories]))))
 
 (defn perform [{:keys [bufnr winnr] :as cofx} f]
   (try
@@ -50,9 +51,12 @@
         {:db (-> (:db cofx)
                  (assoc-in [:buffers bufnr] (:buffer context'))
                  (assoc-in [:windows winnr] (:window context'))
-                 (dissoc :keymap-buffer :pending-operator)
+                 (dissoc :keymap-buffer
+                         :pending-operator
+                         :pending-operator/from-mode)
                  (merge (select-keys context' [:mode
                                                :pending-operator
+                                               :pending-operator/from-mode
                                                :registers]))
                  (cond->
                   (:editable context')

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -196,7 +196,7 @@
 
 ;; Yank (copy)
 
-(defn yank-operator {:char "y"} [context flags]
+(defn yank-operator {:char "y" :read? true} [context flags]
   (let [{:keys [yanked]} (delete-operator context flags)]
     (assoc context :yanked yanked)))
 
@@ -204,7 +204,8 @@
 
 (defn- enqueue-operator [operator]
   (fn operator-keymap [{:keys [buffer] :as context}]
-    (if (and (buffers/readonly? buffer)
+    (if (and (not (:read? (meta operator)))
+             (buffers/readonly? buffer)
              (nil? (:editable context)))
       {:error "Read-only buffer"}
 

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -211,6 +211,7 @@
 
       (assoc context
              :mode :operator-pending
+             :pending-operator/from-mode (:mode context)
              :pending-operator operator))))
 
 (def operator-keymaps

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -16,7 +16,8 @@
                                             end-of-word-movement
                                             small-word-boundary? word-movement]]
    [saya.modules.input.shared :refer [to-end-of-line to-start-of-line]]
-   [saya.modules.search.core :as search]))
+   [saya.modules.search.core :as search]
+   [saya.util.coll :refer [insert-into-vec]]))
 
 ; ======= Mode-change keymaps ==============================
 
@@ -222,18 +223,35 @@
   (fn perform-edit [ctx]
     (operator ctx (movement->operation motion ctx))))
 
-(def ^:private paste-selected-register
+(defn- paste-selected-register [where]
   (with-editable
     (fn [{:keys [buffer registers] :as ctx}]
       (let [reg-id \"]
         (m/match [(get registers reg-id)]
+          [nil]
+          (-> ctx
+              (assoc :error (str "Nothing in register " reg-id)))
+
           [{:chars to-paste}]
           (-> ctx
               (update-cursor-line-string
                (fn [line]
                  (let [[before after] (split-text-by-state buffer line)]
                    (str before to-paste after))))
-              ((update-cursor :col (partial + (dec (count to-paste)))))))))))
+              ((update-cursor :col (partial + (dec (count to-paste))))))
+
+          [{:lines lines}]
+          (-> ctx
+              (update-in [:buffer :lines]
+                         insert-into-vec
+                         (cond-> (get-in buffer [:cursor :row])
+                           (= :after where)
+                           (inc))
+                         lines)
+              (cond->
+               (= :after where)
+                (update-in [:buffer :cursor :row] inc))
+              (assoc-in [:buffer :cursor :col] 0)))))))
 
 (def edit-keymaps
   {["C"] (create-edit-with-operator
@@ -253,9 +271,9 @@
           #'delete-operator
           (update-cursor :col dec))
 
-   ["p"] (comp paste-selected-register
+   ["p"] (comp (paste-selected-register :after)
                (update-cursor :col inc))
-   ["P"] paste-selected-register})
+   ["P"] (paste-selected-register :before)})
 
 ; ======= Scroll keymaps ===================================
 

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -245,7 +245,8 @@
               (update-in [:buffer :lines]
                          insert-into-vec
                          (cond-> (get-in buffer [:cursor :row])
-                           (= :after where)
+                           (and (seq (get-in ctx [:buffer :lines]))
+                                (= :after where))
                            (inc))
                          lines)
               (cond->

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -1,6 +1,7 @@
 (ns saya.modules.input.normal
   (:require
-   [saya.cli.text-input.helpers :refer [dec-to-zero]]
+   [clojure.core.match :as m]
+   [saya.cli.text-input.helpers :refer [dec-to-zero split-text-by-state]]
    [saya.modules.buffers.line :refer [wrapped-lines]]
    [saya.modules.buffers.util :as buffers]
    [saya.modules.input.helpers :refer [adjust-cursor-to-scroll
@@ -9,7 +10,8 @@
                                        current-buffer-line-last-col
                                        last-buffer-row movement->operation
                                        update-cursor]]
-   [saya.modules.input.insert :refer [line->string update-buffer-line-string]]
+   [saya.modules.input.insert :refer [line->string update-buffer-line-string
+                                      update-cursor-line-string]]
    [saya.modules.input.motions.word :refer [big-word-boundary?
                                             end-of-word-movement
                                             small-word-boundary? word-movement]]
@@ -162,17 +164,24 @@
         (assoc :yanked {:chars (subs (line->string (nth (:lines buffer) linenr))
                                      start end)}))))
 
+(defn- unpack-buffer-yanked [{{:keys [yanked]} :buffer :as context}]
+  (-> context
+      (update :buffer dissoc :yanked)
+      (assoc :yanked yanked)))
+
 (defn delete-operator {:char "d"} [context {:keys [start end linewise?] :as flags}]
   (cond
     ; Line-wise delete
     linewise?
-    (update context :buffer delete-lines (:row start) (:row end))
+    (-> (update context :buffer delete-lines (:row start) (:row end))
+        (unpack-buffer-yanked))
 
     ; Char-wise delete within a line
     (= (:row start) (:row end))
     (-> context
         (update :buffer delete-chars flags (:row start) (:col start) (:col end))
-        (clamp-cursor))
+        (clamp-cursor)
+        (unpack-buffer-yanked))
 
     :else
     {:error "TODO: support char-wise cross-line deletes"}))
@@ -183,6 +192,12 @@
   (-> context
       (assoc :mode :insert)
       (delete-operator flags)))
+
+;; Yank (copy)
+
+(defn yank-operator {:char "y"} [context flags]
+  (let [{:keys [yanked]} (delete-operator context flags)]
+    (assoc context :yanked yanked)))
 
 ;; Integration
 
@@ -198,13 +213,27 @@
 
 (def operator-keymaps
   {["c"] (enqueue-operator #'change-operator)
-   ["d"] (enqueue-operator #'delete-operator)})
+   ["d"] (enqueue-operator #'delete-operator)
+   ["y"] (enqueue-operator #'yank-operator)})
 
 ; ======= Edit keymaps =====================================
 
 (defn- create-edit-with-operator [operator motion]
   (fn perform-edit [ctx]
     (operator ctx (movement->operation motion ctx))))
+
+(def ^:private paste-selected-register
+  (with-editable
+    (fn [{:keys [buffer registers] :as ctx}]
+      (let [reg-id \"]
+        (m/match [(get registers reg-id)]
+          [{:chars to-paste}]
+          (-> ctx
+              (update-cursor-line-string
+               (fn [line]
+                 (let [[before after] (split-text-by-state buffer line)]
+                   (str before to-paste after))))
+              ((update-cursor :col (partial + (dec (count to-paste)))))))))))
 
 (def edit-keymaps
   {["C"] (create-edit-with-operator
@@ -213,13 +242,20 @@
    ["D"] (create-edit-with-operator
           #'delete-operator
           #'to-end-of-line)
+   ["Y"] (create-edit-with-operator
+          #'yank-operator
+          #'to-end-of-line)
 
    ["x"] (create-edit-with-operator
           #'delete-operator
           (update-cursor :col inc))
    ["X"] (create-edit-with-operator
           #'delete-operator
-          (update-cursor :col dec))})
+          (update-cursor :col dec))
+
+   ["p"] (comp paste-selected-register
+               (update-cursor :col inc))
+   ["P"] paste-selected-register})
 
 ; ======= Scroll keymaps ===================================
 

--- a/src/cli/saya/modules/input/normal.cljs
+++ b/src/cli/saya/modules/input/normal.cljs
@@ -2,7 +2,7 @@
   (:require
    [clojure.core.match :as m]
    [saya.cli.text-input.helpers :refer [dec-to-zero split-text-by-state]]
-   [saya.modules.buffers.line :refer [wrapped-lines]]
+   [saya.modules.buffers.line :refer [buffer-line wrapped-lines]]
    [saya.modules.buffers.util :as buffers]
    [saya.modules.input.helpers :refer [adjust-cursor-to-scroll
                                        adjust-scroll-to-cursor clamp-cursor
@@ -148,7 +148,7 @@
         (assoc :lines (into (subvec lines 0 start)
                             (subvec lines (inc end))))
         (assoc-in [:cursor :row] start)
-        (assoc :yanked {:lines yanked}))))
+        (assoc :yanked {:lines (mapv line->string yanked)}))))
 
 (defn- delete-chars [buffer {:keys [inclusive?]} linenr start end]
   (let [[start end] (align-start-end start end)
@@ -248,7 +248,7 @@
                            (and (seq (get-in ctx [:buffer :lines]))
                                 (= :after where))
                            (inc))
-                         lines)
+                         (map buffer-line lines))
               (cond->
                (= :after where)
                 (update-in [:buffer :cursor :row] inc))

--- a/src/cli/saya/modules/input/op.cljs
+++ b/src/cli/saya/modules/input/op.cljs
@@ -14,7 +14,7 @@
     (let [motion-range (get-range context)
           ; TODO: There's eg o_v for turning a normally line-wise
           ; motion into a character-wise one
-          context (dissoc context ::linewise?)]
+          context (dissoc context :input/linewise?)]
       (if-not (= (:start motion-range) (:end motion-range))
         (-> context
             (pending-operator motion-range)
@@ -102,5 +102,5 @@
   {[:full-line] (comp
                  (movement->motion #'to-end-of-line)
                  (fn [ctx]
-                   (assoc ctx ::linewise? true))
+                   (assoc ctx :input/linewise? true))
                  to-start-of-line)})

--- a/src/cli/saya/modules/scripting/core.cljs
+++ b/src/cli/saya/modules/scripting/core.cljs
@@ -112,6 +112,12 @@
           (p/catch (fn [e]
                      (echo-core/echo :exception "ERROR in config: " e)))))))
 
+; ======= Config ===========================================
+
+#_{:clojure-lsp/ignore [:clojure-lsp/unused-public-var]}
+(defn config [& {:as kvs}]
+  (>evt [:config/upsert kvs]))
+
 ; ======= Simple APIs ======================================
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}

--- a/src/cli/saya/modules/window/subs.cljs
+++ b/src/cli/saya/modules/window/subs.cljs
@@ -131,9 +131,15 @@
      (get-in prompts [0 0]))))
 
 (reg-sub
+ ::pending-operator
+ :-> :pending-operator)
+
+(reg-sub
  ::conn-pending-operator?
  :<- [:mode]
  :<- [:current-buffer]
- (fn [[mode buffer]]
+ :<- [::pending-operator]
+ (fn [[mode buffer op]]
    (and (= :operator-pending mode)
-        (some? (:connection-id buffer)))))
+        (some? (:connection-id buffer))
+        (not (:read? (meta op))))))

--- a/src/cli/saya/modules/window/subs.cljs
+++ b/src/cli/saya/modules/window/subs.cljs
@@ -138,8 +138,10 @@
  ::conn-pending-operator?
  :<- [:mode]
  :<- [:current-buffer]
+ :<- [:pending-operator/from-mode]
  :<- [::pending-operator]
- (fn [[mode buffer op]]
+ (fn [[mode buffer from-mode op]]
    (and (= :operator-pending mode)
         (some? (:connection-id buffer))
-        (not (:read? (meta op))))))
+        (or (not (:read? (meta op)))
+            (= :prompt from-mode)))))

--- a/src/cli/saya/subs.cljs
+++ b/src/cli/saya/subs.cljs
@@ -12,6 +12,10 @@
 (reg-sub :last-winnr :-> :last-winnr)
 
 (reg-sub
+ :pending-operator/from-mode
+ :-> :pending-operator/from-mode)
+
+(reg-sub
  :current-window
  :<- [:windows]
  :<- [:current-winnr]

--- a/src/cli/saya/util/coll.cljs
+++ b/src/cli/saya/util/coll.cljs
@@ -20,3 +20,8 @@
                 (next coll)))
 
        [nil not-found before]))))
+
+(defn insert-into-vec [v idx entries]
+  (-> (subvec v 0 idx)
+      (into entries)
+      (into (subvec v idx))))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -236,3 +236,16 @@
     (with-keys-compare-buffer ["X"]
       "Talkin awa|y"
       "Talkin aw|y")))
+
+(deftest yank-paste-test
+  (testing "Paste after"
+    (with-keys-compare-buffer ["p"]
+      "I| know"
+      "I don't| know"
+      :registers {\" {:chars "don't "}}))
+
+  (testing "Paste before"
+    (with-keys-compare-buffer ["P"]
+      "I |know"
+      "I don't| know"
+      :registers {\" {:chars "don't "}})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -1,6 +1,7 @@
 (ns saya.modules.input.normal-test
   (:require
    [cljs.test :refer-macros [deftest testing]]
+   [saya.modules.buffers.line :refer [buffer-line]]
    [saya.modules.input.helpers :refer [update-cursor]]
    [saya.modules.input.normal :as normal :refer [delete-operator update-scroll]]
    [saya.modules.input.test-helpers :refer [with-keymap-compare-buffer]]))
@@ -242,10 +243,20 @@
     (with-keys-compare-buffer ["p"]
       "I| know"
       "I don't| know"
-      :registers {\" {:chars "don't "}}))
+      :registers {\" {:chars "don't "}})
+    (with-keys-compare-buffer ["p"]
+      "I don't| know"
+      "I don't know
+       |what I'm to say"
+      :registers {\" {:lines [(buffer-line "what I'm to say")]}}))
 
   (testing "Paste before"
     (with-keys-compare-buffer ["P"]
       "I |know"
       "I don't| know"
-      :registers {\" {:chars "don't "}})))
+      :registers {\" {:chars "don't "}})
+    (with-keys-compare-buffer ["P"]
+      "what I'm |to say"
+      "|I don't know
+       what I'm to say"
+      :registers {\" {:lines [(buffer-line "I don't know")]}})))

--- a/src/test/saya/modules/input/normal_test.cljs
+++ b/src/test/saya/modules/input/normal_test.cljs
@@ -259,4 +259,15 @@
       "what I'm |to say"
       "|I don't know
        what I'm to say"
+      :registers {\" {:lines [(buffer-line "I don't know")]}}))
+
+  (testing "Empty buffer"
+    (with-keys-compare-buffer ["p"]
+      "|"
+      "I don't kno|w"
+      :registers {\" {:chars "I don't know"}})
+
+    (with-keys-compare-buffer ["p"]
+      "|"
+      "|I don't know"
       :registers {\" {:lines [(buffer-line "I don't know")]}})))

--- a/src/test/saya/modules/input/test_helpers.cljs
+++ b/src/test/saya/modules/input/test_helpers.cljs
@@ -58,12 +58,13 @@
                              (insert-cursor cursor))))))
        (into [])))
 
-(defn make-context [& {:keys [buffer window]}]
+(defn make-context [& {:keys [buffer registers window]}]
   {:buffer (or (when (and buffer (not= :empty buffer))
                  (str->buffer buffer))
                (-> (buffer-events/create-blank default-db)
                    (second)
                    :buffer))
+   :registers registers
    :window (merge {:height 2 :width 20} window)
    :mode :normal})
 
@@ -73,12 +74,19 @@
 
 (defn with-keymap-compare-buffer
   [f buffer-before buffer-after & {:keys [window window-expect pending-operator
-                                          mode-expect]}]
+                                          mode-expect registers]}]
   (let [ctx (-> (make-context :buffer buffer-before
+                              :registers registers
                               :window window)
                 (assoc :pending-operator pending-operator))
         ctx' (try (binding [*mode* (:mode ctx)]
-                    (f ctx))
+                    (if (coll? f)
+                      (reduce
+                       (fn [ctx' f']
+                         (f' ctx'))
+                       ctx
+                       f)
+                      (f ctx)))
                   (catch :default e
                     (println "ERROR performing " f ": " e)
                     (println (.-stack e))

--- a/src/test/saya/util/coll_test.cljs
+++ b/src/test/saya/util/coll_test.cljs
@@ -1,0 +1,26 @@
+(ns saya.util.coll-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [saya.util.coll :refer [insert-into-vec]]))
+
+(deftest insert-into-vec-test
+  (testing "Insert at start of vec"
+    (is (= [1 2 3 4 5 6]
+           (insert-into-vec
+            [4 5 6]
+            0
+            [1 2 3]))))
+
+  (testing "Insert at middle of vec"
+    (is (= [1 2 3 4 5 6]
+           (insert-into-vec
+            [1 2 5 6]
+            2
+            [3 4]))))
+
+  (testing "Insert at end of vec"
+    (is (= [1 2 3 4 5 6]
+           (insert-into-vec
+            [1 2 3]
+            3
+            [4 5 6])))))
+

--- a/src/test/saya/util/coll_test.cljs
+++ b/src/test/saya/util/coll_test.cljs
@@ -3,6 +3,13 @@
             [saya.util.coll :refer [insert-into-vec]]))
 
 (deftest insert-into-vec-test
+  (testing "Insert into empty vec"
+    (is (= [1 2 3]
+           (insert-into-vec
+            []
+            0
+            [1 2 3]))))
+
   (testing "Insert at start of vec"
     (is (= [1 2 3 4 5 6]
            (insert-into-vec


### PR DESCRIPTION
Closes #38

- **Add initial yank integration + char-wise paste**
- **Fix: properly forward :linewise? flag to the motion**
- **Add preliminary support for linewise paste**
- **Handle empty buffers more gracefully**
- **Yank plaintext, not ansi**
- **Cleanly support yanking from the output buffer**
- **Fix support for yanking within the connection input buffer**
- **Add `(saya/config :clipboard :unnamedplus)` to integrate with system**
